### PR TITLE
Fix crash when passing phone number with plus to `extractPotentialCou…

### DIFF
--- a/PhoneNumberKit/PhoneNumberParser.swift
+++ b/PhoneNumberKit/PhoneNumberParser.swift
@@ -81,18 +81,21 @@ class PhoneNumberParser {
             return 0
         }
         let numberLength = nsFullNumber.length
-        var maxCountryCode = PNMaxLengthCountryCode
+        let maxCountryCode = PNMaxLengthCountryCode
+        var startPosition = 0
         if (fullNumber.hasPrefix("+")) {
-            maxCountryCode = PNMaxLengthCountryCode + 1
+            if (nsFullNumber.length == 1) {
+                return 0
+            }
+            startPosition = 1
         }
         for var i = 1; i <= maxCountryCode && i <= numberLength; i++ {
-            let stringRange = NSMakeRange(0, i)
+            let stringRange = NSMakeRange(startPosition, i)
             let subNumber = nsFullNumber.substringWithRange(stringRange)
-            let potentialCountryCode = UInt64(subNumber)
-            let regionCodes = metadata.metadataPerCode[potentialCountryCode!]
-            if (regionCodes != nil) {
-                nationalNumber = nsFullNumber.substringFromIndex(i)
-                return potentialCountryCode
+            if let potentialCountryCode = UInt64(subNumber)
+                where metadata.metadataPerCode[potentialCountryCode] != nil {
+                    nationalNumber = nsFullNumber.substringFromIndex(i)
+                    return potentialCountryCode
             }
         }
         return 0


### PR DESCRIPTION
The function ``` extractPotentialCountryCode(fullNumber: String, inout nationalNumber: String) -> UInt64?``` was crasion when one passes a phone number with plus ("+33 612-345-678"). The crash was due to force-unwrapping `potentialCountryCode`. This variable was nil because `UInt64("+3")` returns nil.