### PR TITLE
Fixed deprecation warnings encountered with Xcode version 7.3 beta 2 …

### DIFF
--- a/PhoneNumberKit/PhoneNumberParser.swift
+++ b/PhoneNumberKit/PhoneNumberParser.swift
@@ -93,7 +93,10 @@ class PhoneNumberParser {
             }
             startPosition = 1
         }
-        for var i = 1; i <= maxCountryCode && i <= numberLength; i++ {
+        for i in 1...numberLength {
+            if i > maxCountryCode {
+                break
+            }
             let stringRange = NSMakeRange(startPosition, i)
             let subNumber = nsFullNumber.substringWithRange(stringRange)
             if let potentialCountryCode = UInt64(subNumber)

--- a/PhoneNumberKit/RegularExpressions.swift
+++ b/PhoneNumberKit/RegularExpressions.swift
@@ -228,7 +228,7 @@ class RegularExpressions {
     func stringByReplacingOccurrences(string: String, map: [String:String], removeNonMatches: Bool) -> String {
         var targetString = String()
         let copiedString = string
-        for var i = 0; i < string.characters.count; i++ {
+        for i in 0 ..< string.characters.count {
             let oneChar = copiedString[copiedString.startIndex.advancedBy(i)]
             let keyString = String(oneChar)
             if let mappedValue = map[keyString.uppercaseString] {

--- a/PhoneNumberKitTests/PhoneNumberKitParsingTests.swift
+++ b/PhoneNumberKitTests/PhoneNumberKitParsingTests.swift
@@ -226,7 +226,7 @@ class PhoneNumberKitParsingTests: XCTestCase {
         let startTime = NSDate()
         var endTime = NSDate()
         var numberArray: [String] = []
-        for var numberIdx = 0; numberIdx < numberOfParses; numberIdx++ {
+        for _ in 0 ..< numberOfParses {
             numberArray.append("+5491187654321")
         }
         let phoneNumbers = PhoneNumberKit().parseMultiple(numberArray, region: "AR")


### PR DESCRIPTION
…(7D129n). Warnings are part of Swift language deprecations introduced in Swift 2.2 in preparation for Swift 3.0. Since these changes are backwards compatible with 2.0, it likely makes sense to adopt now.