### PR TITLE
Adds send of UIControlEvents.EditingChanged for PhoneNumberTextField

### DIFF
--- a/PhoneNumberKit/TextField.swift
+++ b/PhoneNumberKit/TextField.swift
@@ -143,10 +143,12 @@ public class PhoneNumberTextField: UITextField, UITextFieldDelegate {
         {
             selectedTextRange = selectionRangeForNumberReplacement(textField, formattedText: modifiedTextField)
             textField.text = modifiedTextField
+            sendActionsForControlEvents(.EditingChanged)
         }
         else {
             selectedTextRange = selectionRangeForNumberReplacement(textField, formattedText: formattedNationalNumber)
             textField.text = formattedNationalNumber
+            sendActionsForControlEvents(.EditingChanged)
         }
         if let selectedTextRange = selectedTextRange, let selectionRangePosition = textField.positionFromPosition(beginningOfDocument, offset: selectedTextRange.location) {
             let selectionRange = textField.textRangeFromPosition(selectionRangePosition, toPosition: selectionRangePosition)


### PR DESCRIPTION
Hi @marmelroy,  thanks you very much for this awesome work on the AsYouTypeFormatter! :+1: 

I've been using it with success, however I've encountered an issue when my inputs have targets added for  `UIControlEvents.EditingChanged`, they became silent after using `PhoneNumberTextField`

```swift
input.addTarget(self, action: "changed", forControlEvents: UIControlEvents.EditingChanged)
```

Adding `sendActionsForControlEvents(.EditingChanged )` where needed fixed my issue.