### PR TITLE
PhoneNumberTextField consults delegate before editing, and reports currentRegion and isValidNumber

### DIFF
--- a/PhoneNumberKit/PartialFormatter.swift
+++ b/PhoneNumberKit/PartialFormatter.swift
@@ -21,7 +21,18 @@ public class PartialFormatter {
     var currentMetadata: MetadataTerritory?
     var prefixBeforeNationalNumber =  String()
     var shouldAddSpaceAfterNationalPrefix = false
+    
+    //MARK: Status
 
+    public var currentRegion: String {
+        get {
+            return currentMetadata?.codeID ?? defaultRegion
+        }
+    }
+
+    private(set) var validNumber = false
+    
+    
     //MARK: Lifecycle
     
     /**
@@ -55,6 +66,13 @@ public class PartialFormatter {
      - returns: Formatted phone number string.
      */
     public func formatPartial(rawNumber: String) -> String {
+        // determine if number is valid by trying to instantiate a PhoneNumber object with it
+        do {
+            try _ = PhoneNumber(rawNumber: rawNumber)
+            validNumber = true
+        } catch {
+            validNumber = false
+        }
         // Check if number is valid for parsing, if not return raw
         if isValidRawNumber(rawNumber) == false {
             return rawNumber

--- a/PhoneNumberKit/PartialFormatter.swift
+++ b/PhoneNumberKit/PartialFormatter.swift
@@ -30,7 +30,7 @@ public class PartialFormatter {
         }
     }
 
-    private(set) var validNumber = false
+    private(set) var isValidNumber = false
     
     
     //MARK: Lifecycle
@@ -69,9 +69,9 @@ public class PartialFormatter {
         // determine if number is valid by trying to instantiate a PhoneNumber object with it
         do {
             try _ = PhoneNumber(rawNumber: rawNumber)
-            validNumber = true
+            isValidNumber = true
         } catch {
-            validNumber = false
+            isValidNumber = false
         }
         // Check if number is valid for parsing, if not return raw
         if isValidRawNumber(rawNumber) == false {

--- a/PhoneNumberKit/TextField.swift
+++ b/PhoneNumberKit/TextField.swift
@@ -132,6 +132,12 @@ public class PhoneNumberTextField: UITextField, UITextFieldDelegate {
         guard let text = text else {
             return false
         }
+
+        // allow delegate to intervene
+        guard _delegate?.textField?(textField, shouldChangeCharactersInRange: range, replacementString: string) ?? true else {
+            return false
+        }
+
         let textAsNSString = text as NSString
         let changedRange = textAsNSString.substringWithRange(range) as NSString
         let modifiedTextField = textAsNSString.stringByReplacingCharactersInRange(range, withString: string)

--- a/PhoneNumberKit/TextField.swift
+++ b/PhoneNumberKit/TextField.swift
@@ -38,6 +38,19 @@ public class PhoneNumberTextField: UITextField, UITextFieldDelegate {
         }
     }
     
+    //MARK: Status
+
+    public var currentRegion: String {
+        get {
+            return partialFormatter.currentRegion
+        }
+    }
+    public var validNumber: Bool {
+        get {
+            return partialFormatter.validNumber
+        }
+    }
+    
      //MARK: Lifecycle
     
     /**

--- a/PhoneNumberKit/TextField.swift
+++ b/PhoneNumberKit/TextField.swift
@@ -45,9 +45,9 @@ public class PhoneNumberTextField: UITextField, UITextFieldDelegate {
             return partialFormatter.currentRegion
         }
     }
-    public var validNumber: Bool {
+    public var isValidNumber: Bool {
         get {
-            return partialFormatter.validNumber
+            return partialFormatter.isValidNumber
         }
     }
     


### PR DESCRIPTION
Currently `PhoneNumberTextField` passes all `UITextFieldDelegate` methods to its `_delegate`, except for `textfield(shouldChangeCharactersInRange...)`. I think the right implementation would be to check with the delegate first, and if the delegate says no, stop processing.

Usage case: I'm pre-populating the text field with a + at the beginning and don't want to let the user erase the +. I should be able to accomplish this by setting a delegate on PhoneNumberTextField with

```swift
func textField(textField: UITextField, shouldChangeCharactersInRange range: NSRange, replacementString string: String) -> Bool {
    return range.location != 0
}
```