### PR TITLE
improvements to PartialFormatter region prediction

### DIFF
--- a/PhoneNumberKit/PartialFormatter.swift
+++ b/PhoneNumberKit/PartialFormatter.swift
@@ -66,19 +66,18 @@ public class PartialFormatter {
      - returns: Formatted phone number string.
      */
     public func formatPartial(rawNumber: String) -> String {
-        // determine if number is valid by trying to instantiate a PhoneNumber object with it
+        // Always reset variables with each new raw number
+        resetVariables()
+        // Check if number is valid for parsing, if not return raw
+        guard isValidRawNumber(rawNumber) else {
+            return rawNumber
+        }
+        // Determine if number is valid by trying to instantiate a PhoneNumber object with it
         do {
             try _ = PhoneNumber(rawNumber: rawNumber)
             isValidNumber = true
-        } catch {
-            isValidNumber = false
-        }
-        // Check if number is valid for parsing, if not return raw
-        if isValidRawNumber(rawNumber) == false {
-            return rawNumber
-        }
-        // Reset variables
-        resetVariables()
+        } catch {}
+        
         let iddFreeNumber = extractIDD(rawNumber)
         var nationalNumber = parser.normalizePhoneNumber(iddFreeNumber)
         if prefixBeforeNationalNumber.characters.count > 0 {
@@ -119,6 +118,7 @@ public class PartialFormatter {
     //MARK: Formatting Functions
     
     internal func resetVariables() {
+        isValidNumber = false
         currentMetadata = defaultMetadata
         prefixBeforeNationalNumber = String()
         shouldAddSpaceAfterNationalPrefix = false
@@ -127,11 +127,9 @@ public class PartialFormatter {
     //MARK: Formatting Tests
     
     internal func isValidRawNumber(rawNumber: String) -> Bool {
-        if rawNumber.isEmpty || rawNumber.characters.count < 3 {
-            return false
-        }
         do {
-            let validNumberMatches = try regex.regexMatches(validPhoneNumberPattern, string: rawNumber)
+            let validPartialPattern = "[+＋]?(\\s*\\d\\s*)+$|\(validPhoneNumberPattern)"
+            let validNumberMatches = try regex.regexMatches(validPartialPattern, string: rawNumber)
             let validStart = regex.stringPositionByRegex(validStartPattern, string: rawNumber)
             if validNumberMatches.count == 0 || validStart != 0 {
                 return false

--- a/PhoneNumberKit/PartialFormatter.swift
+++ b/PhoneNumberKit/PartialFormatter.swift
@@ -128,7 +128,9 @@ public class PartialFormatter {
     
     internal func isValidRawNumber(rawNumber: String) -> Bool {
         do {
-            let validPartialPattern = "[+＋]?(\\s*\\d\\s*)+$|\(validPhoneNumberPattern)"
+            // In addition to validPhoneNumberPattern, 
+            // accept any sequence of digits and whitespace, prefixed or not by a plus sign
+            let validPartialPattern = "[+＋]?(\\s*\\d)+\\s*$|\(validPhoneNumberPattern)"
             let validNumberMatches = try regex.regexMatches(validPartialPattern, string: rawNumber)
             let validStart = regex.stringPositionByRegex(validStartPattern, string: rawNumber)
             if validNumberMatches.count == 0 || validStart != 0 {

--- a/PhoneNumberKitTests/PartialFormatterTests.swift
+++ b/PhoneNumberKitTests/PartialFormatterTests.swift
@@ -265,11 +265,8 @@ class PartialFormatterTests: XCTestCase {
         let partialFormatter = PartialFormatter(region: "DE")
         partialFormatter.formatPartial("+1 212 555 1212")
         XCTAssertEqual(partialFormatter.currentRegion, "US")
-        partialFormatter.formatPartial("akareanvatheroaengaekf")
+        partialFormatter.formatPartial("invalid raw number")
         XCTAssertEqual(partialFormatter.currentRegion, "DE")
     }
-    
-    
-    
 }
 

--- a/PhoneNumberKitTests/PartialFormatterTests.swift
+++ b/PhoneNumberKitTests/PartialFormatterTests.swift
@@ -248,5 +248,28 @@ class PartialFormatterTests: XCTestCase {
         XCTAssertEqual(partialFormatter.formatPartial(testNumber), "07739 555555")
     }
     
+    // MARK: region prediction
+    func testMinimalFrenchNumber() {
+        let partialFormatter = PartialFormatter(region: "US")
+        partialFormatter.formatPartial("+33")
+        XCTAssertEqual(partialFormatter.currentRegion, "FR")
+    }
+    
+    func testMinimalUSNumberFromFrance() {
+        let partialFormatter = PartialFormatter(region: "FR")
+        partialFormatter.formatPartial("+1")
+        XCTAssertEqual(partialFormatter.currentRegion, "US")
+    }
+    
+    func testRegionResetsWithEachCallToFormatPartial() {
+        let partialFormatter = PartialFormatter(region: "DE")
+        partialFormatter.formatPartial("+1 212 555 1212")
+        XCTAssertEqual(partialFormatter.currentRegion, "US")
+        partialFormatter.formatPartial("akareanvatheroaengaekf")
+        XCTAssertEqual(partialFormatter.currentRegion, "DE")
+    }
+    
+    
+    
 }
 


### PR DESCRIPTION
Now that `PartialFormatter` exposes its best guess for `currentRegion`, some tuning is needed to get it to guess better. Or more to the point to guess sooner. Currently for example:
```swift
p = PartialFormatter(region: "FR")
p.formatPartial(rawNumber: "+1")
p.currentRegion  // returns "FR"; should be "US"
p.formatPartial(rawNumber: "+19")
p.currentRegion  // returns "FR"; should be "US"
p.formatPartial(rawNumber: "+191")
p.currentRegion  // correctly returns "US"
```
The problem is that `formatPartial(...)` doesn't process strings that don't pass `isValidRawNumber(...)`, and `isValidRawNumber(...)` rejects short strings.

So I made `isValidRawNumber(...)` less restrictive, removing the length >= 3 requirement and adding a more permissive regex `[+＋]?(\s*\d)+\s*$`. This accepts any sequence of digits and whitespace, prefixed or not by a plus sign.

Another problem was that `resetVariables()` was only being called if `isValidRawNumber(...)` returned true. That meant that the `currentRegion` value was stickier than it should have been:

```swift
p = PartialFormatter(region: "US")
p.formatPartial(rawNumber: "+33 3")
p.currentRegion  // returns "FR"
p.formatPartial(rawNumber: "+")
p.currentRegion  // returns "FR"; should revert to "US"
```

I moved the `resetVariables()` call to before `isValidRawNumber(...)`, so that the variables get reset with every new `rawNumber`.