### PR TITLE
Make Constants public for easier subclassing

### DIFF
--- a/PhoneNumberKit/Constants.swift
+++ b/PhoneNumberKit/Constants.swift
@@ -9,7 +9,6 @@
 import Foundation
 
 // MARK: Private Enums
-
 enum PhoneNumberCountryCodeSource {
     case NumberWithPlusSign
     case NumberWithIDD
@@ -85,50 +84,55 @@ public enum PhoneNumberType {
 
 // MARK: Constants
 
-let defaultCountry = "US"
-let defaultExtnPrefix = " ext. "
-let firstGroupPattern = "(\\$\\d)"
-let fgPattern = "\\$FG"
-let longPhoneNumber = "999999999999999"
-let minLengthForNSN = 2
-let maxInputStringLength = 250
-let maxLengthCountryCode = 3
-let maxLengthForNSN = 16
-let nonBreakingSpace = "\u{00a0}"
-let npPattern = "\\$NP"
-let plusChars = "+＋"
-let validDigitsString = "0-9０-９٠-٩۰-۹"
-let digitPlaceholder = "\u{2008}"
-let separatorBeforeNationalNumber = " "
+public struct PhoneNumberConstants {
+  public static let defaultCountry = "US"
+  public static let defaultExtnPrefix = " ext. "
+  public static let longPhoneNumber = "999999999999999"
+  public static let minLengthForNSN = 2
+  public static let maxInputStringLength = 250
+  public static let maxLengthCountryCode = 3
+  public static let maxLengthForNSN = 16
+  public static let nonBreakingSpace = "\u{00a0}"
+  public static let plusChars = "+＋"
+  public static let validDigitsString = "0-9０-９٠-٩۰-۹"
+  public static let digitPlaceholder = "\u{2008}"
+  public static let separatorBeforeNationalNumber = " "
+}
 
-// MARK: Patterns
+public struct PhoneNumberPatterns {
+  // MARK: Patterns
+  
+  public static let firstGroupPattern = "(\\$\\d)"
+  public static let fgPattern = "\\$FG"
+  public static let npPattern = "\\$NP"
 
-let allNormalizationMappings = ["0":"0", "1":"1", "2":"2", "3":"3", "4":"4", "5":"5", "6":"6", "7":"7", "8":"8", "9":"9", "\u{FF10}":"0", "\u{FF11}":"1", "\u{FF12}":"2", "\u{FF13}":"3", "\u{FF14}":"4", "\u{FF15}":"5", "\u{FF16}":"6", "\u{FF17}":"7", "\u{FF18}":"8", "\u{FF19}":"9", "\u{0660}":"0", "\u{0661}":"1", "\u{0662}":"2", "\u{0663}":"3", "\u{0664}":"4", "\u{0665}":"5", "\u{0666}":"6", "\u{0667}":"7", "\u{0668}":"8", "\u{0669}":"9", "\u{06F0}":"0", "\u{06F1}":"1", "\u{06F2}":"2", "\u{06F3}":"3", "\u{06F4}":"4", "\u{06F5}":"5", "\u{06F6}":"6", "\u{06F7}":"7", "\u{06F8}":"8", "\u{06F9}":"9"]
+  public static let allNormalizationMappings = ["0":"0", "1":"1", "2":"2", "3":"3", "4":"4", "5":"5", "6":"6", "7":"7", "8":"8", "9":"9", "\u{FF10}":"0", "\u{FF11}":"1", "\u{FF12}":"2", "\u{FF13}":"3", "\u{FF14}":"4", "\u{FF15}":"5", "\u{FF16}":"6", "\u{FF17}":"7", "\u{FF18}":"8", "\u{FF19}":"9", "\u{0660}":"0", "\u{0661}":"1", "\u{0662}":"2", "\u{0663}":"3", "\u{0664}":"4", "\u{0665}":"5", "\u{0666}":"6", "\u{0667}":"7", "\u{0668}":"8", "\u{0669}":"9", "\u{06F0}":"0", "\u{06F1}":"1", "\u{06F2}":"2", "\u{06F3}":"3", "\u{06F4}":"4", "\u{06F5}":"5", "\u{06F6}":"6", "\u{06F7}":"7", "\u{06F8}":"8", "\u{06F9}":"9"]
 
-let capturingDigitPattern = "([0-9０-９٠-٩۰-۹])"
+  public static let capturingDigitPattern = "([0-9０-９٠-٩۰-۹])"
 
-let extnPattern = "\\;(.*)"
+  public static let extnPattern = "\\;(.*)"
 
-let iddPattern = "^(?:\\+|%@)"
+  public static let iddPattern = "^(?:\\+|%@)"
 
-let formatPattern = "^(?:%@)$"
+  public static let formatPattern = "^(?:%@)$"
 
-let characterClassPattern = "\\[([^\\[\\]])*\\]"
+  public static let characterClassPattern = "\\[([^\\[\\]])*\\]"
 
-let standaloneDigitPattern = "\\d(?=[^,}][^,}])"
+  public static let standaloneDigitPattern = "\\d(?=[^,}][^,}])"
 
-let nationalPrefixParsingPattern = "^(?:%@)"
+  public static let nationalPrefixParsingPattern = "^(?:%@)"
 
-let prefixSeparatorPattern = "[- ]"
+  public static let prefixSeparatorPattern = "[- ]"
 
-let eligibleAsYouTypePattern = "^[-x‐-―−ー－-／ ­​⁠　()（）［］.\\[\\]/~⁓∼～]*(\\$\\d[-x‐-―−ー－-／ ­​⁠　()（）［］.\\[\\]/~⁓∼～]*)+$"
+  public static let eligibleAsYouTypePattern = "^[-x‐-―−ー－-／ ­​⁠　()（）［］.\\[\\]/~⁓∼～]*(\\$\\d[-x‐-―−ー－-／ ­​⁠　()（）［］.\\[\\]/~⁓∼～]*)+$"
 
-let leadingPlusCharsPattern = "^[+＋]+"
+  public static let leadingPlusCharsPattern = "^[+＋]+"
 
-let secondNumberStartPattern = "[\\\\\\/] *x"
+  public static let secondNumberStartPattern = "[\\\\\\/] *x"
 
-let unwantedEndPattern = "[^0-9０-９٠-٩۰-۹A-Za-z#]+$"
+  public static let unwantedEndPattern = "[^0-9０-９٠-٩۰-۹A-Za-z#]+$"
 
-let validStartPattern = "[+＋0-9０-９٠-٩۰-۹]"
+  public static let validStartPattern = "[+＋0-9０-９٠-٩۰-۹]"
 
-let validPhoneNumberPattern = "^[0-9０-９٠-٩۰-۹]{2}$|^[+＋]*(?:[-x\u{2010}-\u{2015}\u{2212}\u{30FC}\u{FF0D}-\u{FF0F} \u{00A0}\u{00AD}\u{200B}\u{2060}\u{3000}()\u{FF08}\u{FF09}\u{FF3B}\u{FF3D}.\\[\\]/~\u{2053}\u{223C}\u{FF5E}*]*[0-9\u{FF10}-\u{FF19}\u{0660}-\u{0669}\u{06F0}-\u{06F9}]){3,}[-x\u{2010}-\u{2015}\u{2212}\u{30FC}\u{FF0D}-\u{FF0F} \u{00A0}\u{00AD}\u{200B}\u{2060}\u{3000}()\u{FF08}\u{FF09}\u{FF3B}\u{FF3D}.\\[\\]/~\u{2053}\u{223C}\u{FF5E}*A-Za-z0-9\u{FF10}-\u{FF19}\u{0660}-\u{0669}\u{06F0}-\u{06F9}]*(?:(?:;ext=([0-9０-９٠-٩۰-۹]{1,7})|[  \\t,]*(?:e?xt(?:ensi(?:ó?|ó))?n?|ｅ?ｘｔｎ?|[,xｘX#＃~～]|int|anexo|ｉｎｔ)[:\\.．]?[  \\t,-]*([0-9０-９٠-٩۰-۹]{1,7})#?|[- ]+([0-9０-９٠-٩۰-۹]{1,5})#)?$)?$"
+  public static let validPhoneNumberPattern = "^[0-9０-９٠-٩۰-۹]{2}$|^[+＋]*(?:[-x\u{2010}-\u{2015}\u{2212}\u{30FC}\u{FF0D}-\u{FF0F} \u{00A0}\u{00AD}\u{200B}\u{2060}\u{3000}()\u{FF08}\u{FF09}\u{FF3B}\u{FF3D}.\\[\\]/~\u{2053}\u{223C}\u{FF5E}*]*[0-9\u{FF10}-\u{FF19}\u{0660}-\u{0669}\u{06F0}-\u{06F9}]){3,}[-x\u{2010}-\u{2015}\u{2212}\u{30FC}\u{FF0D}-\u{FF0F} \u{00A0}\u{00AD}\u{200B}\u{2060}\u{3000}()\u{FF08}\u{FF09}\u{FF3B}\u{FF3D}.\\[\\]/~\u{2053}\u{223C}\u{FF5E}*A-Za-z0-9\u{FF10}-\u{FF19}\u{0660}-\u{0669}\u{06F0}-\u{06F9}]*(?:(?:;ext=([0-9０-９٠-٩۰-۹]{1,7})|[  \\t,]*(?:e?xt(?:ensi(?:ó?|ó))?n?|ｅ?ｘｔｎ?|[,xｘX#＃~～]|int|anexo|ｉｎｔ)[:\\.．]?[  \\t,-]*([0-9０-９٠-٩۰-۹]{1,7})#?|[- ]+([0-9０-９٠-٩۰-۹]{1,5})#)?$)?$"
+}

--- a/PhoneNumberKit/Formatter.swift
+++ b/PhoneNumberKit/Formatter.swift
@@ -42,7 +42,7 @@ class Formatter {
                 return "\(preferredExtnPrefix)\(extns)"
             }
             else {
-                return "\(defaultExtnPrefix)\(extns)"
+                return "\(PhoneNumberConstants.defaultExtnPrefix)\(extns)"
             }
         }
         return nil
@@ -79,11 +79,11 @@ class Formatter {
             var formattedNationalNumber = String()
             var prefixFormattingRule = String()
             if let nationalPrefixFormattingRule = formatPattern.nationalPrefixFormattingRule, let nationalPrefix = regionMetadata.nationalPrefix {
-                prefixFormattingRule = regex.replaceStringByRegex(npPattern, string: nationalPrefixFormattingRule, template: nationalPrefix)
-                prefixFormattingRule = regex.replaceStringByRegex(fgPattern, string: prefixFormattingRule, template:"\\$1")
+                prefixFormattingRule = regex.replaceStringByRegex(PhoneNumberPatterns.npPattern, string: nationalPrefixFormattingRule, template: nationalPrefix)
+                prefixFormattingRule = regex.replaceStringByRegex(PhoneNumberPatterns.fgPattern, string: prefixFormattingRule, template:"\\$1")
             }
             if formatType == PhoneNumberFormat.National && regex.hasValue(prefixFormattingRule){
-                let replacePattern = regex.replaceFirstStringByRegex(firstGroupPattern, string: numberFormatRule, templateString: prefixFormattingRule)
+                let replacePattern = regex.replaceFirstStringByRegex(PhoneNumberPatterns.firstGroupPattern, string: numberFormatRule, templateString: prefixFormattingRule)
                 formattedNationalNumber = self.regex.replaceStringByRegex(pattern, string: nationalNumber, template: replacePattern)
             }
             else {

--- a/PhoneNumberKit/ParseManager.swift
+++ b/PhoneNumberKit/ParseManager.swift
@@ -43,7 +43,7 @@ class ParseManager {
         }
         catch {
             do {
-                let plusRemovedNumberString = self.regex.replaceStringByRegex(leadingPlusCharsPattern, string: nationalNumber as String)
+                let plusRemovedNumberString = self.regex.replaceStringByRegex(PhoneNumberPatterns.leadingPlusCharsPattern, string: nationalNumber as String)
                 countryCode = try self.parser.extractCountryCode(plusRemovedNumberString, nationalNumber: &nationalNumber, metadata: regionMetadata)
             }
             catch {

--- a/PhoneNumberKit/PartialFormatter.swift
+++ b/PhoneNumberKit/PartialFormatter.swift
@@ -30,8 +30,8 @@ public class PartialFormatter {
         }
     }
 
-    private(set) var isValidNumber = false
-    
+    public private(set) var isValidNumber = false
+  
     
     //MARK: Lifecycle
     
@@ -102,13 +102,13 @@ public class PartialFormatter {
         if prefixBeforeNationalNumber.characters.count > 0 {
             finalNumber.appendContentsOf(prefixBeforeNationalNumber)
         }
-        if shouldAddSpaceAfterNationalPrefix && prefixBeforeNationalNumber.characters.count > 0 && prefixBeforeNationalNumber.characters.last != separatorBeforeNationalNumber.characters.first  {
-            finalNumber.appendContentsOf(separatorBeforeNationalNumber)
+        if shouldAddSpaceAfterNationalPrefix && prefixBeforeNationalNumber.characters.count > 0 && prefixBeforeNationalNumber.characters.last != PhoneNumberConstants.separatorBeforeNationalNumber.characters.first  {
+            finalNumber.appendContentsOf(PhoneNumberConstants.separatorBeforeNationalNumber)
         }
         if nationalNumber.characters.count > 0 {
             finalNumber.appendContentsOf(nationalNumber)
         }
-        if finalNumber.characters.last == separatorBeforeNationalNumber.characters.first {
+        if finalNumber.characters.last == PhoneNumberConstants.separatorBeforeNationalNumber.characters.first {
             finalNumber = finalNumber.substringToIndex(finalNumber.endIndex.predecessor())
         }
 
@@ -130,9 +130,9 @@ public class PartialFormatter {
         do {
             // In addition to validPhoneNumberPattern, 
             // accept any sequence of digits and whitespace, prefixed or not by a plus sign
-            let validPartialPattern = "[+＋]?(\\s*\\d)+\\s*$|\(validPhoneNumberPattern)"
+            let validPartialPattern = "[+＋]?(\\s*\\d)+\\s*$|\(PhoneNumberPatterns.validPhoneNumberPattern)"
             let validNumberMatches = try regex.regexMatches(validPartialPattern, string: rawNumber)
-            let validStart = regex.stringPositionByRegex(validStartPattern, string: rawNumber)
+            let validStart = regex.stringPositionByRegex(PhoneNumberPatterns.validStartPattern, string: rawNumber)
             if validNumberMatches.count == 0 || validStart != 0 {
                 return false
             }
@@ -155,7 +155,7 @@ public class PartialFormatter {
             return false
         }
         do {
-            let validRegex = try regex.regexWithPattern(eligibleAsYouTypePattern)
+            let validRegex = try regex.regexWithPattern(PhoneNumberPatterns.eligibleAsYouTypePattern)
             if validRegex.firstMatchInString(phoneFormat, options: [], range: NSMakeRange(0, phoneFormat.characters.count)) != nil {
                 return true
             }
@@ -170,7 +170,7 @@ public class PartialFormatter {
         var processedNumber = rawNumber
         do {
             if let internationalPrefix = currentMetadata?.internationalPrefix {
-                let prefixPattern = String(format: iddPattern, arguments: [internationalPrefix])
+                let prefixPattern = String(format: PhoneNumberPatterns.iddPattern, arguments: [internationalPrefix])
                 let matches = try regex.matchedStringByRegex(prefixPattern, string: rawNumber)
                 if let m = matches.first {
                     let startCallingCode = m.characters.count
@@ -195,7 +195,7 @@ public class PartialFormatter {
         else {
             do {
                 if let nationalPrefix = currentMetadata?.nationalPrefixForParsing {
-                    let nationalPrefixPattern = String(format: nationalPrefixParsingPattern, arguments: [nationalPrefix])
+                    let nationalPrefixPattern = String(format: PhoneNumberPatterns.nationalPrefixParsingPattern, arguments: [nationalPrefix])
                     let matches = try regex.matchedStringByRegex(nationalPrefixPattern, string: rawNumber)
                     if let m = matches.first {
                         startOfNationalNumber = m.characters.count
@@ -219,7 +219,7 @@ public class PartialFormatter {
         }
         var numberWithoutCountryCallingCode = String()
         if prefixBeforeNationalNumber.isEmpty == false && prefixBeforeNationalNumber.characters.first != "+" {
-            prefixBeforeNationalNumber.appendContentsOf(separatorBeforeNationalNumber)
+            prefixBeforeNationalNumber.appendContentsOf(PhoneNumberConstants.separatorBeforeNationalNumber)
         }
         if let potentialCountryCode = self.parser.extractPotentialCountryCode(rawNumber, nationalNumber: &numberWithoutCountryCallingCode) where potentialCountryCode != 0 {
             processedNumber = numberWithoutCountryCallingCode
@@ -263,12 +263,12 @@ public class PartialFormatter {
     func applyFormat(rawNumber: String, formats: [MetadataPhoneNumberFormat]) -> String? {
         for format in formats {
             if let pattern = format.pattern, let formatTemplate = format.format {
-                let patternRegExp = String(format: formatPattern, arguments: [pattern])
+                let patternRegExp = String(format: PhoneNumberPatterns.formatPattern, arguments: [pattern])
                 do {
                     let matches = try regex.regexMatches(patternRegExp, string: rawNumber)
                     if matches.count > 0 {
                         if let nationalPrefixFormattingRule = format.nationalPrefixFormattingRule {
-                            let separatorRegex = try regex.regexWithPattern(prefixSeparatorPattern)
+                            let separatorRegex = try regex.regexWithPattern(PhoneNumberPatterns.prefixSeparatorPattern)
                             let nationalPrefixMatches = separatorRegex.matchesInString(nationalPrefixFormattingRule, options: [], range:  NSMakeRange(0, nationalPrefixFormattingRule.characters.count))
                             if nationalPrefixMatches.count > 0 {
                                 shouldAddSpaceAfterNationalPrefix = true
@@ -296,19 +296,19 @@ public class PartialFormatter {
             return nil
         }
         do {
-            let characterClassRegex = try regex.regexWithPattern(characterClassPattern)
+            let characterClassRegex = try regex.regexWithPattern(PhoneNumberPatterns.characterClassPattern)
             var nsString = numberPattern as NSString
             var stringRange = NSMakeRange(0, nsString.length)
             numberPattern = characterClassRegex.stringByReplacingMatchesInString(numberPattern, options: [], range: stringRange, withTemplate: "\\\\d")
     
-            let standaloneDigitRegex = try regex.regexWithPattern(standaloneDigitPattern)
+            let standaloneDigitRegex = try regex.regexWithPattern(PhoneNumberPatterns.standaloneDigitPattern)
             nsString = numberPattern as NSString
             stringRange = NSMakeRange(0, nsString.length)
             numberPattern = standaloneDigitRegex.stringByReplacingMatchesInString(numberPattern, options: [], range: stringRange, withTemplate: "\\\\d")
             
             if let tempTemplate = getFormattingTemplate(numberPattern, numberFormat: numberFormat, rawNumber: rawNumber) {
                 if let nationalPrefixFormattingRule = format.nationalPrefixFormattingRule {
-                    let separatorRegex = try regex.regexWithPattern(prefixSeparatorPattern)
+                    let separatorRegex = try regex.regexWithPattern(PhoneNumberPatterns.prefixSeparatorPattern)
                     let nationalPrefixMatch = separatorRegex.firstMatchInString(nationalPrefixFormattingRule, options: [], range:  NSMakeRange(0, nationalPrefixFormattingRule.characters.count))
                     if nationalPrefixMatch != nil {
                         shouldAddSpaceAfterNationalPrefix = true
@@ -323,13 +323,13 @@ public class PartialFormatter {
     
     func getFormattingTemplate(numberPattern: String, numberFormat: String, rawNumber: String) -> String? {
         do {
-            let matches =  try regex.matchedStringByRegex(numberPattern, string: longPhoneNumber)
+            let matches =  try regex.matchedStringByRegex(numberPattern, string: PhoneNumberConstants.longPhoneNumber)
             if let match = matches.first {
                 if match.characters.count < rawNumber.characters.count {
                     return nil
                 }
                 var template = regex.replaceStringByRegex(numberPattern, string: match, template: numberFormat)
-                template = regex.replaceStringByRegex("9", string: template, template: digitPlaceholder)
+                template = regex.replaceStringByRegex("9", string: template, template: PhoneNumberConstants.digitPlaceholder)
                 return template
             }
         }
@@ -343,7 +343,7 @@ public class PartialFormatter {
         var rebuiltString = String()
         var rebuiltIndex = 0
         for character in template.characters {
-            if character == digitPlaceholder.characters.first {
+            if character == PhoneNumberConstants.digitPlaceholder.characters.first {
                 if rebuiltIndex < rawNumber.characters.count {
                     let nationalCharacterIndex = rawNumber.startIndex.advancedBy(rebuiltIndex)
                     rebuiltString.append(rawNumber[nationalCharacterIndex])

--- a/PhoneNumberKit/PhoneNumberKit.swift
+++ b/PhoneNumberKit/PhoneNumberKit.swift
@@ -91,7 +91,7 @@ public class PhoneNumberKit: NSObject {
                 return countryCode.uppercaseString
             }
         }
-        return defaultCountry
+        return PhoneNumberConstants.defaultCountry
     }
 
 }

--- a/PhoneNumberKit/PhoneNumberParser.swift
+++ b/PhoneNumberKit/PhoneNumberParser.swift
@@ -23,7 +23,7 @@ class PhoneNumberParser {
     - Returns: Normalized phone number string.
     */
     func normalizePhoneNumber(number: String) -> String {
-        return regex.stringByReplacingOccurrences(number, map: allNormalizationMappings, removeNonMatches: true)
+        return regex.stringByReplacingOccurrences(number, map: PhoneNumberPatterns.allNormalizationMappings, removeNonMatches: true)
     }
 
     // MARK: Extractions
@@ -42,7 +42,7 @@ class PhoneNumberParser {
         }
         let countryCodeSource = stripInternationalPrefixAndNormalize(&fullNumber, possibleIddPrefix: possibleCountryIddPrefix)
         if countryCodeSource != .DefaultCountry {
-            if fullNumber.characters.count <= minLengthForNSN {
+            if fullNumber.characters.count <= PhoneNumberConstants.minLengthForNSN {
                 throw PhoneNumberError.TooShort
             }
             if let potentialCountryCode = extractPotentialCountryCode(fullNumber, nationalNumber: &nationalNumber) where potentialCountryCode != 0 {
@@ -85,7 +85,7 @@ class PhoneNumberParser {
             return 0
         }
         let numberLength = nsFullNumber.length
-        let maxCountryCode = maxLengthCountryCode
+        let maxCountryCode = PhoneNumberConstants.maxLengthCountryCode
         var startPosition = 0
         if fullNumber.hasPrefix("+") {
             if nsFullNumber.length == 1 {
@@ -199,12 +199,12 @@ class PhoneNumberParser {
                 let matchedString = number.substringWithNSRange(matched.range)
                 let matchEnd = matchedString.characters.count
                 let remainString: NSString = nsString.substringFromIndex(matchEnd)
-                let capturingDigitPatterns = try NSRegularExpression(pattern: capturingDigitPattern, options:NSRegularExpressionOptions.CaseInsensitive)
+                let capturingDigitPatterns = try NSRegularExpression(pattern: PhoneNumberPatterns.capturingDigitPattern, options:NSRegularExpressionOptions.CaseInsensitive)
                 let matchedGroups = capturingDigitPatterns.matchesInString(remainString as String, options: [], range: NSMakeRange(0, remainString.length))
                 if let firstMatch = matchedGroups.first {
                     let digitMatched = remainString.substringWithRange(firstMatch.range) as NSString
                     if digitMatched.length > 0 {
-                        let normalizedGroup =  regex.stringByReplacingOccurrences(digitMatched as String, map: allNormalizationMappings, removeNonMatches: true)
+                        let normalizedGroup =  regex.stringByReplacingOccurrences(digitMatched as String, map: PhoneNumberPatterns.allNormalizationMappings, removeNonMatches: true)
                         if normalizedGroup == "0" {
                             return false
                         }
@@ -229,7 +229,7 @@ class PhoneNumberParser {
     */
     func stripExtension(inout number: String) -> String? {
         do {
-            let matches = try regex.regexMatches(extnPattern, string: number)
+            let matches = try regex.regexMatches(PhoneNumberPatterns.extnPattern, string: number)
             if let match = matches.first {
                 let adjustedRange = NSMakeRange(match.range.location + 1, match.range.length - 1)
                 let matchString = number.substringWithNSRange(adjustedRange)
@@ -251,8 +251,8 @@ class PhoneNumberParser {
     - Returns: Modified normalized number without international prefix and a PNCountryCodeSource enumeration.
     */
     func stripInternationalPrefixAndNormalize(inout number: String, possibleIddPrefix: String?) -> PhoneNumberCountryCodeSource {
-        if (regex.matchesAtStart(leadingPlusCharsPattern, string: number as String)) {
-            number = regex.replaceStringByRegex(leadingPlusCharsPattern, string: number as String)
+        if (regex.matchesAtStart(PhoneNumberPatterns.leadingPlusCharsPattern, string: number as String)) {
+            number = regex.replaceStringByRegex(PhoneNumberPatterns.leadingPlusCharsPattern, string: number as String)
             return .NumberWithPlusSign
         }
         number = normalizePhoneNumber(number as String)

--- a/PhoneNumberKit/RegularExpressions.swift
+++ b/PhoneNumberKit/RegularExpressions.swift
@@ -84,7 +84,7 @@ class RegularExpressions {
             return matches
         }
         else {
-            let fallBackMatches = try regexMatches(validPhoneNumberPattern, string: string)
+            let fallBackMatches = try regexMatches(PhoneNumberPatterns.validPhoneNumberPattern, string: string)
             if fallBackMatches.isEmpty == false {
                 return fallBackMatches
             }

--- a/PhoneNumberKit/TextField.swift
+++ b/PhoneNumberKit/TextField.swift
@@ -23,7 +23,7 @@ public class PhoneNumberTextField: UITextField, UITextFieldDelegate {
     
     let nonNumericSet: NSCharacterSet = {
         var mutableSet = NSCharacterSet.decimalDigitCharacterSet().invertedSet.mutableCopy() as! NSMutableCharacterSet
-        mutableSet.removeCharactersInString(plusChars)
+        mutableSet.removeCharactersInString(PhoneNumberConstants.plusChars)
         return mutableSet
     }()
     

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 # **** Update me when new Xcode versions are released! ****
 PLATFORM="platform=iOS Simulator,OS=9.1,name=iPhone 6"
-SDK="iphonesimulator9.1"
+SDK="iphonesimulator"
 
 
 # It is pitch black.


### PR DESCRIPTION
If you want to use any of the functionality that was used to create `PhoneNumberTextField` in your own project (say making your own custom text field), the constants that this class uses are not publicly available.

The changes here do not change any logic, they just put the constants in a public `struct`. I figured other people might find this useful.

Also, I noticed when running `build.sh` to test the changes, you could set the `PLATFORM` to point to the latest simulator, which makes upgrades easier. :-)