### PR TITLE
Implement regionCodeForNumber

### DIFF
--- a/PhoneNumberKit/MetadataTypes.swift
+++ b/PhoneNumberKit/MetadataTypes.swift
@@ -30,6 +30,7 @@ MetadataTerritory object
 - Parameter voicemail: MetadataPhoneNumberDesc for voice mail numbers
 - Parameter voip: MetadataPhoneNumberDesc for voip numbers
 - Parameter uan: MetadataPhoneNumberDesc for uan numbers
+- Parameter leadingDigits: Optional leading digits for the territory
 */
 struct MetadataTerritory {
     let codeID: String
@@ -54,6 +55,7 @@ struct MetadataTerritory {
     let voip: MetadataPhoneNumberDesc?
     let uan: MetadataPhoneNumberDesc?
     var numberFormats: [MetadataPhoneNumberFormat] = []
+    let leadingDigits: String?
 
 }
 
@@ -108,6 +110,7 @@ extension MetadataTerritory {
                 self.numberFormats.append(processedFormat)
             }
         }
+        self.leadingDigits = jsondDict.valueForKey("leadingDigits") as? String
     }
 }
 

--- a/PhoneNumberKit/PhoneNumberKit.swift
+++ b/PhoneNumberKit/PhoneNumberKit.swift
@@ -68,7 +68,7 @@ public class PhoneNumberKit: NSObject {
 
     /**
     Get the region code for the given phone number
-    - Paramter number: The phone number
+    - Parameter number: The phone number
     - Returns: Region code, eg "US", or nil if the region cannot be determined
     */
     public func regionCodeForNumber(number: PhoneNumber) -> String? {

--- a/PhoneNumberKit/PhoneNumberKit.swift
+++ b/PhoneNumberKit/PhoneNumberKit.swift
@@ -12,7 +12,8 @@ import CoreTelephony
 public class PhoneNumberKit: NSObject {
     
     let metadata = Metadata.sharedInstance
-    
+    let regex = RegularExpressions.sharedInstance
+
     // MARK: Multiple Parsing
     
     /**
@@ -63,6 +64,37 @@ public class PhoneNumberKit: NSObject {
     public func mainCountryForCode(code: UInt64) -> String? {
         let country = metadata.fetchMainCountryMetadataForCode(code)
         return country?.codeID
+    }
+
+    /**
+    Get the region code for the given phone number
+    - Paramter number: The phone number
+    - Returns: Region code, eg "US", or nil if the region cannot be determined
+    */
+    public func regionCodeForNumber(number: PhoneNumber) -> String? {
+        let countryCode = number.countryCode
+        let regions = metadata.items.filter { $0.countryCode == countryCode }
+        if regions.count == 1 {
+            return regions[0].codeID
+        }
+
+        return getRegionCodeForNumber(number, fromRegionList: regions)
+    }
+
+    private func getRegionCodeForNumber(number: PhoneNumber, fromRegionList regions: [MetadataTerritory]) -> String? {
+        let nationalNumber = String(number.nationalNumber)
+        let parser = PhoneNumberParser()
+        for region in regions {
+            if let leadingDigits = region.leadingDigits {
+                if regex.matchesAtStart(leadingDigits, string: nationalNumber) {
+                    return region.codeID
+                }
+            }
+            if parser.checkNumberType(nationalNumber, metadata: region, considerPossible: false) != .Unknown {
+                return region.codeID
+            }
+        }
+        return nil
     }
     
     /**

--- a/PhoneNumberKitTests/PhoneNumberKitTests.swift
+++ b/PhoneNumberKitTests/PhoneNumberKitTests.swift
@@ -260,4 +260,22 @@ class PhoneNumberKitTests: XCTestCase {
         XCTAssertEqual(phoneNumberKit.countriesForCode(424242)?.count, 0)
     }
 
+    //  Test region code for number function
+    func testGetRegionCode() {
+        guard let phoneNumber = try? PhoneNumber(rawNumber: "+39 3123456789") else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(PhoneNumberKit().regionCodeForNumber(phoneNumber), "IT")
+    }
+
+    //  Test region code for number in a region that uses leading digits
+    func testGetRegionCodeLeadingDigits() {
+        guard let phoneNumber = try? PhoneNumber(rawNumber: "876-123-4567") else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(PhoneNumberKit().regionCodeForNumber(phoneNumber), "JM")
+    }
+
 }


### PR DESCRIPTION
Add the ability to get the region associated with a given number.
This is a fairly straightforward port of the algorithm implemented
in Google's libPhoneNumber:

- Get the metadata record(s) associated with the number's country code
- If there is only one record, return its region code
- If there are multiple records, use leadingDigits if present, otherwise
  fallback to checking all number formats

There is a somewhat awkward workaround for #30: The PhoneNumberParser
isNumberMatchingDesc method takes a parameter to allow ignoring
the possible number pattern, with a default value of true to avoid affecting
existing usage.