### PR TITLE
Don't use possible number pattern to determine number type

### DIFF
--- a/PhoneNumberKit/PhoneNumberKit.swift
+++ b/PhoneNumberKit/PhoneNumberKit.swift
@@ -90,7 +90,7 @@ public class PhoneNumberKit: NSObject {
                     return region.codeID
                 }
             }
-            if parser.checkNumberType(nationalNumber, metadata: region, considerPossible: false) != .Unknown {
+            if parser.checkNumberType(nationalNumber, metadata: region) != .Unknown {
                 return region.codeID
             }
         }

--- a/PhoneNumberKit/PhoneNumberParser.swift
+++ b/PhoneNumberKit/PhoneNumberParser.swift
@@ -116,56 +116,56 @@ class PhoneNumberParser {
     - Parameter countryCode:  International country code (e.g 44 for the UK).
     - Returns: Country code is UInt64.
     */
-    func checkNumberType(nationalNumber: String, countryCode: UInt64, considerPossible: Bool = true) -> PhoneNumberType {
+    func checkNumberType(nationalNumber: String, countryCode: UInt64) -> PhoneNumberType {
         guard let metadata = self.metadata.metadataPerCode[countryCode] else {
             return .Unknown
         }
         return checkNumberType(nationalNumber, metadata: metadata)
     }
 
-    func checkNumberType(nationalNumber: String, metadata: MetadataTerritory, considerPossible: Bool = true) -> PhoneNumberType {
+    func checkNumberType(nationalNumber: String, metadata: MetadataTerritory) -> PhoneNumberType {
         guard let generalNumberDesc = metadata.generalDesc else {
             return .Unknown
         }
-        if (regex.hasValue(generalNumberDesc.nationalNumberPattern) == false || isNumberMatchingDesc(nationalNumber, numberDesc: generalNumberDesc, considerPossible: considerPossible) == false) {
+        if (regex.hasValue(generalNumberDesc.nationalNumberPattern) == false || isNumberMatchingDesc(nationalNumber, numberDesc: generalNumberDesc) == false) {
             return .Unknown
         }
-        if (isNumberMatchingDesc(nationalNumber, numberDesc: metadata.fixedLine, considerPossible: considerPossible)) {
+        if (isNumberMatchingDesc(nationalNumber, numberDesc: metadata.fixedLine)) {
             if metadata.fixedLine?.nationalNumberPattern == metadata.mobile?.nationalNumberPattern {
                 return .FixedOrMobile
             }
-            else if (isNumberMatchingDesc(nationalNumber, numberDesc: metadata.mobile, considerPossible: considerPossible)) {
+            else if (isNumberMatchingDesc(nationalNumber, numberDesc: metadata.mobile)) {
                 return .FixedOrMobile
             }
             else {
                 return .FixedLine
             }
         }
-        if (isNumberMatchingDesc(nationalNumber, numberDesc: metadata.mobile, considerPossible: considerPossible)) {
+        if (isNumberMatchingDesc(nationalNumber, numberDesc: metadata.mobile)) {
             return .Mobile
         }
-        if (isNumberMatchingDesc(nationalNumber, numberDesc: metadata.premiumRate, considerPossible: considerPossible)) {
+        if (isNumberMatchingDesc(nationalNumber, numberDesc: metadata.premiumRate)) {
             return .PremiumRate
         }
-        if (isNumberMatchingDesc(nationalNumber, numberDesc: metadata.tollFree, considerPossible: considerPossible)) {
+        if (isNumberMatchingDesc(nationalNumber, numberDesc: metadata.tollFree)) {
             return .TollFree
         }
-        if (isNumberMatchingDesc(nationalNumber, numberDesc: metadata.sharedCost, considerPossible: considerPossible)) {
+        if (isNumberMatchingDesc(nationalNumber, numberDesc: metadata.sharedCost)) {
             return .SharedCost
         }
-        if (isNumberMatchingDesc(nationalNumber, numberDesc: metadata.voip, considerPossible: considerPossible)) {
+        if (isNumberMatchingDesc(nationalNumber, numberDesc: metadata.voip)) {
             return .VOIP
         }
-        if (isNumberMatchingDesc(nationalNumber, numberDesc: metadata.personalNumber, considerPossible: considerPossible)) {
+        if (isNumberMatchingDesc(nationalNumber, numberDesc: metadata.personalNumber)) {
             return .PersonalNumber
         }
-        if (isNumberMatchingDesc(nationalNumber, numberDesc: metadata.pager, considerPossible: considerPossible)) {
+        if (isNumberMatchingDesc(nationalNumber, numberDesc: metadata.pager)) {
             return .Pager
         }
-        if (isNumberMatchingDesc(nationalNumber, numberDesc: metadata.uan, considerPossible: considerPossible)) {
+        if (isNumberMatchingDesc(nationalNumber, numberDesc: metadata.uan)) {
             return .UAN
         }
-        if (isNumberMatchingDesc(nationalNumber, numberDesc: metadata.voicemail, considerPossible: considerPossible)) {
+        if (isNumberMatchingDesc(nationalNumber, numberDesc: metadata.voicemail)) {
             return .Voicemail
         }
         return .Unknown
@@ -175,20 +175,10 @@ class PhoneNumberParser {
      Checks if number matches description.
      - Parameter nationalNumber: National number string.
      - Parameter numberDesc:  MetadataPhoneNumberDesc of a given phone number type.
-     - Parameter considerPossible: Whether the metadata's possible number pattern should be considered.
      - Returns: True or false.
      */
-    func isNumberMatchingDesc(nationalNumber: String, numberDesc: MetadataPhoneNumberDesc?, considerPossible: Bool = true) -> Bool {
-        guard let numberDesc = numberDesc else {
-            return false
-        }
-        if !considerPossible || regex.hasValue(numberDesc.possibleNumberPattern) == false || numberDesc.possibleNumberPattern == "NA" {
-            return regex.matchesEntirely(numberDesc.nationalNumberPattern, string: nationalNumber)
-        }
-        if regex.hasValue(numberDesc.nationalNumberPattern) == false || numberDesc.nationalNumberPattern == "NA" {
-            return regex.matchesEntirely(numberDesc.possibleNumberPattern, string: nationalNumber)
-        }
-        return regex.matchesEntirely(numberDesc.possibleNumberPattern, string: nationalNumber) || regex.matchesEntirely(numberDesc.nationalNumberPattern, string: nationalNumber)
+    func isNumberMatchingDesc(nationalNumber: String, numberDesc: MetadataPhoneNumberDesc?) -> Bool {
+        return regex.matchesEntirely(numberDesc?.nationalNumberPattern, string: nationalNumber)
     }
     
     /**

--- a/PhoneNumberKit/RegularExpressions.swift
+++ b/PhoneNumberKit/RegularExpressions.swift
@@ -137,24 +137,11 @@ class RegularExpressions {
 
     
     func matchesEntirely(pattern: String?, string: String) -> Bool {
-        guard let pattern = pattern else {
+        guard var pattern = pattern else {
             return false
         }
-        var isMatchingEntirely: Bool = false
-        do {
-            let matches = try regexMatches(pattern, string: string)
-            let nsString = string as NSString
-            let stringRange = NSMakeRange(0, nsString.length)
-            for match in matches {
-                if (NSEqualRanges(match.range, stringRange)) {
-                    isMatchingEntirely = true
-                }
-            }
-            return isMatchingEntirely
-        }
-        catch {
-            return false
-        }
+        pattern = "^\(pattern)$"
+        return matchesExist(pattern, string: string)
     }
     
     func matchedStringByRegex(pattern: String, string: String) throws -> [String] {

--- a/PhoneNumberKitTests/PhoneNumberKitParsingTests.swift
+++ b/PhoneNumberKitTests/PhoneNumberKitParsingTests.swift
@@ -200,25 +200,39 @@ class PhoneNumberKitParsingTests: XCTestCase {
     }
     
     func testAllExampleNumbers() {
-        do {
-            let metaDataArray = PhoneNumberKit().metadata.items.filter{$0.codeID.characters.count == 2}
-            for metadata in metaDataArray {
-                let codeID = metadata.codeID
-                let metaDataDescriptions = [metadata.generalDesc, metadata.fixedLine, metadata.mobile, metadata.tollFree, metadata.premiumRate, metadata.sharedCost, metadata.voip, metadata.voicemail, metadata.pager, metadata.uan, metadata.emergency]
-                for desc in metaDataDescriptions {
-                    if desc != nil {
-                        let exampleNumber = desc?.exampleNumber
-                        if exampleNumber != nil {
-                            let phoneNumber = try PhoneNumber(rawNumber: exampleNumber!, region: codeID)
+        let metaDataArray = PhoneNumberKit().metadata.items.filter{$0.codeID.characters.count == 2}
+        for metadata in metaDataArray {
+            let codeID = metadata.codeID
+            let metaDataDescriptions = [metadata.generalDesc, metadata.fixedLine, metadata.mobile, metadata.tollFree, metadata.premiumRate, metadata.sharedCost, metadata.voip, metadata.voicemail, metadata.pager, metadata.uan, metadata.emergency]
+            for desc in metaDataDescriptions {
+                if desc != nil {
+                    if let exampleNumber = desc?.exampleNumber {
+                        do {
+                            let phoneNumber = try PhoneNumber(rawNumber: exampleNumber, region: codeID)
                             XCTAssertNotNil(phoneNumber)
+                        } catch (let e) {
+                            XCTFail("Failed to create PhoneNumber for \(exampleNumber): \(e)")
                         }
                     }
                 }
             }
         }
-        catch {
+    }
+
+    func testRegexMatchesEntirely() {
+        let pattern = "[2-9]\\d{8}|860\\d{9}"
+        let number = "860123456789"
+        let regex = RegularExpressions()
+        XCTAssert(regex.matchesEntirely(pattern, string: number))
+        XCTAssertFalse(regex.matchesEntirely("8", string: number))
+    }
+
+    func testUSTollFreeNumberType() {
+        guard let number = try? PhoneNumber(rawNumber: "8002345678") else {
             XCTFail()
+            return
         }
+        XCTAssertEqual(number.type, PhoneNumberType.TollFree)
     }
 
     func testPerformanceSimple() {


### PR DESCRIPTION
The phone number type determination should never use the possible
number pattern, since that pattern is generic and not necessarily
specific to the type in question.

Update `isNumberMatchingDesc` to always use the national number pattern,
not the possible number pattern.

Also found and fixed a bug in RegularExpressions matchesEntirely while
making this change.