### PR TITLE
Fixes for PhoneNumber type determination

### DIFF
--- a/PhoneNumberKit/PhoneNumber.swift
+++ b/PhoneNumberKit/PhoneNumber.swift
@@ -27,7 +27,7 @@ public struct PhoneNumber {
     public var type: PhoneNumberType {
         get {
             let parser = PhoneNumberParser()
-            let type: PhoneNumberType = parser.checkNumberType(String(nationalNumber), countryCode: countryCode)
+            let type: PhoneNumberType = parser.checkNumberType(self)
             return type
         }
     }

--- a/PhoneNumberKit/PhoneNumberKit.swift
+++ b/PhoneNumberKit/PhoneNumberKit.swift
@@ -90,6 +90,9 @@ public class PhoneNumberKit: NSObject {
                     return region.codeID
                 }
             }
+            if number.leadingZero && parser.checkNumberType("0" + nationalNumber, metadata: region) != .Unknown {
+                return region.codeID
+            }
             if parser.checkNumberType(nationalNumber, metadata: region) != .Unknown {
                 return region.codeID
             }

--- a/PhoneNumberKit/PhoneNumberParser.swift
+++ b/PhoneNumberKit/PhoneNumberParser.swift
@@ -112,14 +112,23 @@ class PhoneNumberParser {
     
     /**
     Check number type (e.g +33 612-345-678 to .Mobile).
-    - Parameter nationalNumber: National number string.
-    - Parameter countryCode:  International country code (e.g 44 for the UK).
-    - Returns: Country code is UInt64.
+    - Parameter phoneNumber: The number to check
+    - Returns: The type of the number
     */
-    func checkNumberType(nationalNumber: String, countryCode: UInt64) -> PhoneNumberType {
-        guard let metadata = self.metadata.metadataPerCode[countryCode] else {
+    func checkNumberType(phoneNumber: PhoneNumber) -> PhoneNumberType {
+        guard let region = PhoneNumberKit().regionCodeForNumber(phoneNumber) else {
             return .Unknown
         }
+        guard let metadata = metadata.fetchMetadataForCountry(region) else {
+            return .Unknown
+        }
+        if phoneNumber.leadingZero {
+            let type = checkNumberType("0" + String(phoneNumber.nationalNumber), metadata: metadata)
+            if type != .Unknown {
+                return type
+            }
+        }
+        let nationalNumber = String(phoneNumber.nationalNumber)
         return checkNumberType(nationalNumber, metadata: metadata)
     }
 
@@ -130,19 +139,8 @@ class PhoneNumberParser {
         if (regex.hasValue(generalNumberDesc.nationalNumberPattern) == false || isNumberMatchingDesc(nationalNumber, numberDesc: generalNumberDesc) == false) {
             return .Unknown
         }
-        if (isNumberMatchingDesc(nationalNumber, numberDesc: metadata.fixedLine)) {
-            if metadata.fixedLine?.nationalNumberPattern == metadata.mobile?.nationalNumberPattern {
-                return .FixedOrMobile
-            }
-            else if (isNumberMatchingDesc(nationalNumber, numberDesc: metadata.mobile)) {
-                return .FixedOrMobile
-            }
-            else {
-                return .FixedLine
-            }
-        }
-        if (isNumberMatchingDesc(nationalNumber, numberDesc: metadata.mobile)) {
-            return .Mobile
+        if (isNumberMatchingDesc(nationalNumber, numberDesc: metadata.pager)) {
+            return .Pager
         }
         if (isNumberMatchingDesc(nationalNumber, numberDesc: metadata.premiumRate)) {
             return .PremiumRate
@@ -159,14 +157,25 @@ class PhoneNumberParser {
         if (isNumberMatchingDesc(nationalNumber, numberDesc: metadata.personalNumber)) {
             return .PersonalNumber
         }
-        if (isNumberMatchingDesc(nationalNumber, numberDesc: metadata.pager)) {
-            return .Pager
-        }
         if (isNumberMatchingDesc(nationalNumber, numberDesc: metadata.uan)) {
             return .UAN
         }
         if (isNumberMatchingDesc(nationalNumber, numberDesc: metadata.voicemail)) {
             return .Voicemail
+        }
+        if (isNumberMatchingDesc(nationalNumber, numberDesc: metadata.fixedLine)) {
+            if metadata.fixedLine?.nationalNumberPattern == metadata.mobile?.nationalNumberPattern {
+                return .FixedOrMobile
+            }
+            else if (isNumberMatchingDesc(nationalNumber, numberDesc: metadata.mobile)) {
+                return .FixedOrMobile
+            }
+            else {
+                return .FixedLine
+            }
+        }
+        if (isNumberMatchingDesc(nationalNumber, numberDesc: metadata.mobile)) {
+            return .Mobile
         }
         return .Unknown
     }

--- a/PhoneNumberKit/RegularExpressions.swift
+++ b/PhoneNumberKit/RegularExpressions.swift
@@ -140,7 +140,7 @@ class RegularExpressions {
         guard var pattern = pattern else {
             return false
         }
-        pattern = "^\(pattern)$"
+        pattern = "^(\(pattern))$"
         return matchesExist(pattern, string: string)
     }
     


### PR DESCRIPTION
Several fixes for determining the type of a phone number:

- Determine which metadata record to use based on the number's region,
  not the numeric country code. This fixes using the US metadata for all
  regions using country code 1, for example.
- Adjust the order we check the type regular expressions. The fixed and
  mobile patterns are the most generic so they should be checked last.
- Some fixes for regions with leading zeros
- Fix regex matchesEntirely - add parentheses to the expression

Also update testAllExampleNumbers to check that the expected type is
computed for all example numbers in the metadata.

This fixes #34.

Note: The metadata resources need to be updated to the latest for all tests to
pass. There is an upstream fix for a couple regular expressions containing
an extra space.