### PR TITLE
Fix wrong region code uses

### DIFF
--- a/PhoneNumberKitTests/PhoneNumberKitTests.swift
+++ b/PhoneNumberKitTests/PhoneNumberKitTests.swift
@@ -64,6 +64,48 @@ class PhoneNumberKitTests: XCTestCase {
         }
     }
 
+    // Invalid BE number, GitHub pr by dulaccc
+    func testInvalidBENumbers() {
+        do {
+            // libphonenumber reports this number as invalid
+            // and it's true, this is a French mobile number combined with the BE region
+            let phoneNumber = try PhoneNumber(rawNumber: "+32910853865")
+            print(phoneNumber.toE164())
+            XCTFail()
+        }
+        catch {
+            XCTAssert(true)
+        }
+    }
+
+    // Invalid CN number, GitHub pr by dulaccc
+    func testInvalidCNNumbers() {
+        do {
+            // libphonenumber reports this number as invalid
+            // and it's true, this is a French mobile number combined with the CN region
+            let phoneNumber = try PhoneNumber(rawNumber: "+861500376135")
+            print(phoneNumber.toE164())
+            XCTFail()
+        }
+        catch {
+            XCTAssert(true)
+        }
+    }
+
+    // Invalid CN number, GitHub pr by dulaccc
+    func testInvalidITNumbers() {
+        do {
+            // libphonenumber reports this number as invalid
+            // and it's true, this is a French mobile number combined with the IT region
+            let phoneNumber = try PhoneNumber(rawNumber: "+390762613915")
+            print(phoneNumber.toE164())
+            XCTFail()
+        }
+        catch {
+            XCTAssert(true)
+        }
+    }
+
     // Italian number with a leading zero
     func testItalianLeadingZero() {
         let testNumber = "+39 0549555555"

--- a/PhoneNumberKitTests/PhoneNumberKitTests.swift
+++ b/PhoneNumberKitTests/PhoneNumberKitTests.swift
@@ -106,12 +106,26 @@ class PhoneNumberKitTests: XCTestCase {
         }
     }
 
-    // Invalid CN number, GitHub pr by dulaccc
+    // Invalid IT number, GitHub pr by dulaccc
     func testInvalidITNumbers() {
         do {
             // libphonenumber reports this number as invalid
             // and it's true, this is a French mobile number combined with the IT region
             let phoneNumber = try PhoneNumber(rawNumber: "+390762613915")
+            print(phoneNumber.toE164())
+            XCTFail()
+        }
+        catch {
+            XCTAssert(true)
+        }
+    }
+
+    // Invalid ES number, GitHub pr by dulaccc
+    func testInvalidESNumbers() {
+        do {
+            // libphonenumber reports this number as invalid
+            // and it's true, this is a French mobile number combined with the ES region
+            let phoneNumber = try PhoneNumber(rawNumber: "+34312431110")
             print(phoneNumber.toE164())
             XCTFail()
         }

--- a/PhoneNumberKitTests/PhoneNumberKitTests.swift
+++ b/PhoneNumberKitTests/PhoneNumberKitTests.swift
@@ -50,6 +50,19 @@ class PhoneNumberKitTests: XCTestCase {
         }
     }
 
+    // Invalid UK number, GitHub pr by dulaccc
+    func testInvalidGBNumbers() {
+        do {
+            // libphonenumber reports this number as invalid
+            // and it's true, this is a French mobile number combined with the GB region
+            let phoneNumber = try PhoneNumber(rawNumber: "+44629996885")
+            print(phoneNumber.toE164())
+            XCTFail()
+        }
+        catch {
+            XCTAssert(true)
+        }
+    }
 
     // Italian number with a leading zero
     func testItalianLeadingZero() {

--- a/PhoneNumberKitTests/PhoneNumberKitTests.swift
+++ b/PhoneNumberKitTests/PhoneNumberKitTests.swift
@@ -78,6 +78,20 @@ class PhoneNumberKitTests: XCTestCase {
         }
     }
 
+    // Invalid DZ number, GitHub pr by dulaccc
+    func testInvalidDZNumbers() {
+        do {
+            // libphonenumber reports this number as invalid
+            // and it's true, this is a French mobile number combined with the DZ region
+            let phoneNumber = try PhoneNumber(rawNumber: "+21373344376")
+            print(phoneNumber.toE164())
+            XCTFail()
+        }
+        catch {
+            XCTAssert(true)
+        }
+    }
+
     // Invalid CN number, GitHub pr by dulaccc
     func testInvalidCNNumbers() {
         do {


### PR DESCRIPTION
Our number validator is getting some weird errors as we expand in other countries.

The numbers are validated on the phone, then if valid transmitted to our backend where an extra step of validation is run. And the backend step is triggering a lot of minor validation issues (mainly due to an incompatible combination between a valid number and a wrong region code).

So I've implemented some failing test for real usage cases that happened for us.
First step toward solving this and making this great project even more robust !

Cheers