### PR TITLE
Fix PartialFormatter for regions that are not the main country

### DIFF
--- a/PhoneNumberKit/PartialFormatter.swift
+++ b/PhoneNumberKit/PartialFormatter.swift
@@ -17,11 +17,19 @@ public class PartialFormatter {
     
     var defaultRegion: String {
         didSet {
-            defaultMetadata = metadata.fetchMetadataForCountry(defaultRegion)
-            currentMetadata = defaultMetadata
+            updateMetadataForDefaultRegion()
         }
     }
-    
+
+    func updateMetadataForDefaultRegion() {
+        if let regionMetadata = metadata.fetchMetadataForCountry(defaultRegion) {
+            defaultMetadata = metadata.fetchMainCountryMetadataForCode(regionMetadata.countryCode)
+        } else {
+            defaultMetadata = nil
+        }
+        currentMetadata = defaultMetadata
+    }
+
     var defaultMetadata: MetadataTerritory?
     var currentMetadata: MetadataTerritory?
     var prefixBeforeNationalNumber =  String()
@@ -59,8 +67,7 @@ public class PartialFormatter {
      */
     public init(defaultRegion: String, withPrefix: Bool = true) {
         self.defaultRegion = defaultRegion
-        self.defaultMetadata = metadata.fetchMetadataForCountry(defaultRegion)
-        self.currentMetadata = defaultMetadata
+        updateMetadataForDefaultRegion()
         self.withPrefix = withPrefix
     }
     

--- a/PhoneNumberKitTests/PartialFormatterTests.swift
+++ b/PhoneNumberKitTests/PartialFormatterTests.swift
@@ -73,7 +73,32 @@ class PartialFormatterTests: XCTestCase {
         XCTAssertEqual(partialFormatter.formatPartial(testNumber), "00 33 6 89 55 55 55")
     }
 
-    
+    // 268 464 1234
+    // Test for number that is not the country code's main country
+    func testAntiguaNumber() {
+        let partialFormatter = PartialFormatter(defaultRegion: "AG")
+        var number = "2"
+        XCTAssertEqual(partialFormatter.formatPartial(number), "2")
+        number = "26"
+        XCTAssertEqual(partialFormatter.formatPartial(number), "26")
+        number = "268"
+        XCTAssertEqual(partialFormatter.formatPartial(number), "268")
+        number = "2684"
+        XCTAssertEqual(partialFormatter.formatPartial(number), "268-4")
+        number = "26846"
+        XCTAssertEqual(partialFormatter.formatPartial(number), "268-46")
+        number = "268464"
+        XCTAssertEqual(partialFormatter.formatPartial(number), "268-464")
+        number = "2684641"
+        XCTAssertEqual(partialFormatter.formatPartial(number), "268-4641")
+        number = "26846412"
+        XCTAssertEqual(partialFormatter.formatPartial(number), "(268) 464-12")
+        number = "268464123"
+        XCTAssertEqual(partialFormatter.formatPartial(number), "(268) 464-123")
+        number = "2684641234"
+        XCTAssertEqual(partialFormatter.formatPartial(number), "(268) 464-1234")
+    }
+
     func testFrenchNumberFromAmericanRegion()  {
         let partialFormatter = PartialFormatter(defaultRegion: "US")
         var testNumber = "+"


### PR DESCRIPTION
The metadata number formats are only specified for the country
code's main country. Since PartialFormatter was using the metadata
of the region code, a region that is not the code's main country
would not have a format and PartialFormatter would leave the input
unchanged.

Fix by always using the main country for the region's country code.
This matches the behavior of libphonenumber.