### PR TITLE
Add macOS, watchOS, tvOS targets

### DIFF
--- a/PhoneNumberKit.xcodeproj/project.pbxproj
+++ b/PhoneNumberKit.xcodeproj/project.pbxproj
@@ -9,7 +9,6 @@
 /* Begin PBXBuildFile section */
 		3420CF5E1BE8959F00FAE34F /* Formatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3420CF5D1BE8959F00FAE34F /* Formatter.swift */; };
 		3422D9BA1BE6A2D500867D02 /* ParseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3422D9B91BE6A2D500867D02 /* ParseManager.swift */; };
-		342418681BB6E5A000EE70E7 /* PhoneNumberKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 342418671BB6E5A000EE70E7 /* PhoneNumberKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3424186F1BB6E5A000EE70E7 /* PhoneNumberKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 342418641BB6E5A000EE70E7 /* PhoneNumberKit.framework */; };
 		342418741BB6E5A000EE70E7 /* PhoneNumberKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 342418731BB6E5A000EE70E7 /* PhoneNumberKitTests.swift */; };
 		342418801BB705B500EE70E7 /* PhoneNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3424187F1BB705B500EE70E7 /* PhoneNumber.swift */; };
@@ -28,6 +27,47 @@
 		34776AA81BE2BF1100400790 /* PhoneNumberKitParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34776AA71BE2BF1100400790 /* PhoneNumberKitParsingTests.swift */; };
 		34AA66021BDD160B00467912 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA66011BDD160B00467912 /* Constants.swift */; };
 		34AA66041BDD448B00467912 /* CoreTelephony.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 34AA66031BDD448B00467912 /* CoreTelephony.framework */; };
+		C6DF6C541D1B09DD00259F4B /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA66011BDD160B00467912 /* Constants.swift */; };
+		C6DF6C551D1B09DD00259F4B /* Formatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3420CF5D1BE8959F00FAE34F /* Formatter.swift */; };
+		C6DF6C561D1B09DD00259F4B /* PartialFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 343B850A1C62A25600918E46 /* PartialFormatter.swift */; };
+		C6DF6C581D1B09DD00259F4B /* Metadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346922661BC01DCC0023482F /* Metadata.swift */; };
+		C6DF6C591D1B09DD00259F4B /* MetadataTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 342548EF1BE7EED500FBE524 /* MetadataTypes.swift */; };
+		C6DF6C5A1D1B09DD00259F4B /* ParseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3422D9B91BE6A2D500867D02 /* ParseManager.swift */; };
+		C6DF6C5B1D1B09DD00259F4B /* ParseOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346DEC0A1BE4B2F900A63274 /* ParseOperation.swift */; };
+		C6DF6C5C1D1B09DD00259F4B /* PhoneNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3424187F1BB705B500EE70E7 /* PhoneNumber.swift */; };
+		C6DF6C5D1D1B09DD00259F4B /* PhoneNumberKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346922681BC023A60023482F /* PhoneNumberKit.swift */; };
+		C6DF6C5E1D1B09DD00259F4B /* PhoneNumberParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 342418811BB70F5200EE70E7 /* PhoneNumberParser.swift */; };
+		C6DF6C5F1D1B09DD00259F4B /* RegularExpressions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34566C991BC112C500715E6B /* RegularExpressions.swift */; };
+		C6DF6C601D1B09E200259F4B /* PhoneNumberMetadata.json in Resources */ = {isa = PBXBuildFile; fileRef = 3435CC951BBFF66F003F953B /* PhoneNumberMetadata.json */; };
+		C6DF6CA81D1B145300259F4B /* PhoneNumberKit.h in Headers */ = {isa = PBXBuildFile; fileRef = C6DF6CA71D1B145300259F4B /* PhoneNumberKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C6DF6CAC1D1B153700259F4B /* PhoneNumberKit.h in Headers */ = {isa = PBXBuildFile; fileRef = C6DF6CAA1D1B152E00259F4B /* PhoneNumberKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C6DF6CAF1D1B154200259F4B /* PhoneNumberKit.h in Headers */ = {isa = PBXBuildFile; fileRef = C6DF6CAD1D1B153F00259F4B /* PhoneNumberKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C6DF6CB21D1B159A00259F4B /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA66011BDD160B00467912 /* Constants.swift */; };
+		C6DF6CB31D1B159A00259F4B /* Formatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3420CF5D1BE8959F00FAE34F /* Formatter.swift */; };
+		C6DF6CB41D1B159A00259F4B /* PartialFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 343B850A1C62A25600918E46 /* PartialFormatter.swift */; };
+		C6DF6CB61D1B159A00259F4B /* Metadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346922661BC01DCC0023482F /* Metadata.swift */; };
+		C6DF6CB71D1B159A00259F4B /* MetadataTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 342548EF1BE7EED500FBE524 /* MetadataTypes.swift */; };
+		C6DF6CB81D1B159A00259F4B /* ParseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3422D9B91BE6A2D500867D02 /* ParseManager.swift */; };
+		C6DF6CB91D1B159A00259F4B /* ParseOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346DEC0A1BE4B2F900A63274 /* ParseOperation.swift */; };
+		C6DF6CBA1D1B159A00259F4B /* PhoneNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3424187F1BB705B500EE70E7 /* PhoneNumber.swift */; };
+		C6DF6CBB1D1B159A00259F4B /* PhoneNumberKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346922681BC023A60023482F /* PhoneNumberKit.swift */; };
+		C6DF6CBC1D1B159A00259F4B /* PhoneNumberParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 342418811BB70F5200EE70E7 /* PhoneNumberParser.swift */; };
+		C6DF6CBD1D1B159A00259F4B /* RegularExpressions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34566C991BC112C500715E6B /* RegularExpressions.swift */; };
+		C6DF6CBE1D1B15A200259F4B /* PhoneNumberMetadata.json in Resources */ = {isa = PBXBuildFile; fileRef = 3435CC951BBFF66F003F953B /* PhoneNumberMetadata.json */; };
+		C6DF6CD41D1B18CE00259F4B /* PhoneNumberKit.h in Headers */ = {isa = PBXBuildFile; fileRef = C6DF6CA71D1B145300259F4B /* PhoneNumberKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C6DF6CD51D1B18D800259F4B /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA66011BDD160B00467912 /* Constants.swift */; };
+		C6DF6CD61D1B18D800259F4B /* Formatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3420CF5D1BE8959F00FAE34F /* Formatter.swift */; };
+		C6DF6CD71D1B18D800259F4B /* PartialFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 343B850A1C62A25600918E46 /* PartialFormatter.swift */; };
+		C6DF6CD81D1B18D800259F4B /* TextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 343B850B1C62A25600918E46 /* TextField.swift */; };
+		C6DF6CD91D1B18D800259F4B /* Metadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346922661BC01DCC0023482F /* Metadata.swift */; };
+		C6DF6CDA1D1B18D800259F4B /* MetadataTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 342548EF1BE7EED500FBE524 /* MetadataTypes.swift */; };
+		C6DF6CDB1D1B18D800259F4B /* ParseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3422D9B91BE6A2D500867D02 /* ParseManager.swift */; };
+		C6DF6CDC1D1B18D800259F4B /* ParseOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346DEC0A1BE4B2F900A63274 /* ParseOperation.swift */; };
+		C6DF6CDD1D1B18D800259F4B /* PhoneNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3424187F1BB705B500EE70E7 /* PhoneNumber.swift */; };
+		C6DF6CDE1D1B18D800259F4B /* PhoneNumberKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346922681BC023A60023482F /* PhoneNumberKit.swift */; };
+		C6DF6CDF1D1B18D800259F4B /* PhoneNumberParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 342418811BB70F5200EE70E7 /* PhoneNumberParser.swift */; };
+		C6DF6CE01D1B18D800259F4B /* RegularExpressions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34566C991BC112C500715E6B /* RegularExpressions.swift */; };
+		C6DF6CE11D1B18DD00259F4B /* PhoneNumberMetadata.json in Resources */ = {isa = PBXBuildFile; fileRef = 3435CC951BBFF66F003F953B /* PhoneNumberMetadata.json */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -44,7 +84,6 @@
 		3420CF5D1BE8959F00FAE34F /* Formatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Formatter.swift; sourceTree = "<group>"; };
 		3422D9B91BE6A2D500867D02 /* ParseManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParseManager.swift; sourceTree = "<group>"; };
 		342418641BB6E5A000EE70E7 /* PhoneNumberKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PhoneNumberKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		342418671BB6E5A000EE70E7 /* PhoneNumberKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PhoneNumberKit.h; sourceTree = "<group>"; };
 		342418691BB6E5A000EE70E7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3424186E1BB6E5A000EE70E7 /* PhoneNumberKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PhoneNumberKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		342418731BB6E5A000EE70E7 /* PhoneNumberKitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneNumberKitTests.swift; sourceTree = "<group>"; };
@@ -64,6 +103,12 @@
 		34776AA71BE2BF1100400790 /* PhoneNumberKitParsingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhoneNumberKitParsingTests.swift; sourceTree = "<group>"; };
 		34AA66011BDD160B00467912 /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		34AA66031BDD448B00467912 /* CoreTelephony.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreTelephony.framework; path = System/Library/Frameworks/CoreTelephony.framework; sourceTree = SDKROOT; };
+		C6DF6C4B1D1B09CF00259F4B /* PhoneNumberKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PhoneNumberKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C6DF6C911D1B120400259F4B /* PhoneNumberKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PhoneNumberKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C6DF6CA71D1B145300259F4B /* PhoneNumberKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PhoneNumberKit.h; sourceTree = "<group>"; };
+		C6DF6CAA1D1B152E00259F4B /* PhoneNumberKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PhoneNumberKit.h; path = macOS/PhoneNumberKit.h; sourceTree = "<group>"; };
+		C6DF6CAD1D1B153F00259F4B /* PhoneNumberKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PhoneNumberKit.h; path = watchOS/PhoneNumberKit.h; sourceTree = "<group>"; };
+		C6DF6CCC1D1B18B000259F4B /* PhoneNumberKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PhoneNumberKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -81,6 +126,27 @@
 			buildActionMask = 2147483647;
 			files = (
 				3424186F1BB6E5A000EE70E7 /* PhoneNumberKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C6DF6C471D1B09CF00259F4B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C6DF6C8D1D1B120400259F4B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C6DF6CC81D1B18B000259F4B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -110,6 +176,9 @@
 			children = (
 				342418641BB6E5A000EE70E7 /* PhoneNumberKit.framework */,
 				3424186E1BB6E5A000EE70E7 /* PhoneNumberKitTests.xctest */,
+				C6DF6C4B1D1B09CF00259F4B /* PhoneNumberKit.framework */,
+				C6DF6C911D1B120400259F4B /* PhoneNumberKit.framework */,
+				C6DF6CCC1D1B18B000259F4B /* PhoneNumberKit.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -117,7 +186,9 @@
 		342418661BB6E5A000EE70E7 /* PhoneNumberKit */ = {
 			isa = PBXGroup;
 			children = (
-				342418671BB6E5A000EE70E7 /* PhoneNumberKit.h */,
+				C6DF6CA71D1B145300259F4B /* PhoneNumberKit.h */,
+				C6DF6CAA1D1B152E00259F4B /* PhoneNumberKit.h */,
+				C6DF6CAD1D1B153F00259F4B /* PhoneNumberKit.h */,
 				342418691BB6E5A000EE70E7 /* Info.plist */,
 				34AA66011BDD160B00467912 /* Constants.swift */,
 				3420CF5D1BE8959F00FAE34F /* Formatter.swift */,
@@ -163,7 +234,31 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				342418681BB6E5A000EE70E7 /* PhoneNumberKit.h in Headers */,
+				C6DF6CA81D1B145300259F4B /* PhoneNumberKit.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C6DF6C481D1B09CF00259F4B /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C6DF6CAC1D1B153700259F4B /* PhoneNumberKit.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C6DF6C8E1D1B120400259F4B /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C6DF6CAF1D1B154200259F4B /* PhoneNumberKit.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C6DF6CC91D1B18B000259F4B /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C6DF6CD41D1B18CE00259F4B /* PhoneNumberKit.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -206,6 +301,60 @@
 			productReference = 3424186E1BB6E5A000EE70E7 /* PhoneNumberKitTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		C6DF6C4A1D1B09CF00259F4B /* PhoneNumberKit-macOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C6DF6C521D1B09CF00259F4B /* Build configuration list for PBXNativeTarget "PhoneNumberKit-macOS" */;
+			buildPhases = (
+				C6DF6C461D1B09CF00259F4B /* Sources */,
+				C6DF6C471D1B09CF00259F4B /* Frameworks */,
+				C6DF6C481D1B09CF00259F4B /* Headers */,
+				C6DF6C491D1B09CF00259F4B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "PhoneNumberKit-macOS";
+			productName = "PhoneNumberKit-macOS";
+			productReference = C6DF6C4B1D1B09CF00259F4B /* PhoneNumberKit.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		C6DF6C901D1B120400259F4B /* PhoneNumberKit-watchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C6DF6C981D1B120400259F4B /* Build configuration list for PBXNativeTarget "PhoneNumberKit-watchOS" */;
+			buildPhases = (
+				C6DF6C8C1D1B120400259F4B /* Sources */,
+				C6DF6C8D1D1B120400259F4B /* Frameworks */,
+				C6DF6C8E1D1B120400259F4B /* Headers */,
+				C6DF6C8F1D1B120400259F4B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "PhoneNumberKit-watchOS";
+			productName = "PhoneNumberKit-watchOS";
+			productReference = C6DF6C911D1B120400259F4B /* PhoneNumberKit.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		C6DF6CCB1D1B18B000259F4B /* PhoneNumberKit-tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C6DF6CD11D1B18B000259F4B /* Build configuration list for PBXNativeTarget "PhoneNumberKit-tvOS" */;
+			buildPhases = (
+				C6DF6CC71D1B18B000259F4B /* Sources */,
+				C6DF6CC81D1B18B000259F4B /* Frameworks */,
+				C6DF6CC91D1B18B000259F4B /* Headers */,
+				C6DF6CCA1D1B18B000259F4B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "PhoneNumberKit-tvOS";
+			productName = "PhoneNumberKit-tvOS";
+			productReference = C6DF6CCC1D1B18B000259F4B /* PhoneNumberKit.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -222,6 +371,15 @@
 					3424186D1BB6E5A000EE70E7 = {
 						CreatedOnToolsVersion = 7.0;
 					};
+					C6DF6C4A1D1B09CF00259F4B = {
+						CreatedOnToolsVersion = 7.3.1;
+					};
+					C6DF6C901D1B120400259F4B = {
+						CreatedOnToolsVersion = 7.3.1;
+					};
+					C6DF6CCB1D1B18B000259F4B = {
+						CreatedOnToolsVersion = 7.3.1;
+					};
 				};
 			};
 			buildConfigurationList = 3424185E1BB6E5A000EE70E7 /* Build configuration list for PBXProject "PhoneNumberKit" */;
@@ -237,6 +395,9 @@
 			projectRoot = "";
 			targets = (
 				342418631BB6E5A000EE70E7 /* PhoneNumberKit */,
+				C6DF6C4A1D1B09CF00259F4B /* PhoneNumberKit-macOS */,
+				C6DF6C901D1B120400259F4B /* PhoneNumberKit-watchOS */,
+				C6DF6CCB1D1B18B000259F4B /* PhoneNumberKit-tvOS */,
 				3424186D1BB6E5A000EE70E7 /* PhoneNumberKitTests */,
 			);
 		};
@@ -256,6 +417,30 @@
 			buildActionMask = 2147483647;
 			files = (
 				3435CCA01BBFF66F003F953B /* PhoneNumberMetadata.json in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C6DF6C491D1B09CF00259F4B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C6DF6C601D1B09E200259F4B /* PhoneNumberMetadata.json in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C6DF6C8F1D1B120400259F4B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C6DF6CBE1D1B15A200259F4B /* PhoneNumberMetadata.json in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C6DF6CCA1D1B18B000259F4B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C6DF6CE11D1B18DD00259F4B /* PhoneNumberMetadata.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -288,6 +473,61 @@
 				34776AA81BE2BF1100400790 /* PhoneNumberKitParsingTests.swift in Sources */,
 				342418741BB6E5A000EE70E7 /* PhoneNumberKitTests.swift in Sources */,
 				346EF14E1C69C688008C7306 /* PartialFormatterTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C6DF6C461D1B09CF00259F4B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C6DF6C5D1D1B09DD00259F4B /* PhoneNumberKit.swift in Sources */,
+				C6DF6C5A1D1B09DD00259F4B /* ParseManager.swift in Sources */,
+				C6DF6C5E1D1B09DD00259F4B /* PhoneNumberParser.swift in Sources */,
+				C6DF6C551D1B09DD00259F4B /* Formatter.swift in Sources */,
+				C6DF6C5C1D1B09DD00259F4B /* PhoneNumber.swift in Sources */,
+				C6DF6C541D1B09DD00259F4B /* Constants.swift in Sources */,
+				C6DF6C5B1D1B09DD00259F4B /* ParseOperation.swift in Sources */,
+				C6DF6C591D1B09DD00259F4B /* MetadataTypes.swift in Sources */,
+				C6DF6C5F1D1B09DD00259F4B /* RegularExpressions.swift in Sources */,
+				C6DF6C581D1B09DD00259F4B /* Metadata.swift in Sources */,
+				C6DF6C561D1B09DD00259F4B /* PartialFormatter.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C6DF6C8C1D1B120400259F4B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C6DF6CBB1D1B159A00259F4B /* PhoneNumberKit.swift in Sources */,
+				C6DF6CB81D1B159A00259F4B /* ParseManager.swift in Sources */,
+				C6DF6CBC1D1B159A00259F4B /* PhoneNumberParser.swift in Sources */,
+				C6DF6CB31D1B159A00259F4B /* Formatter.swift in Sources */,
+				C6DF6CBA1D1B159A00259F4B /* PhoneNumber.swift in Sources */,
+				C6DF6CB21D1B159A00259F4B /* Constants.swift in Sources */,
+				C6DF6CB91D1B159A00259F4B /* ParseOperation.swift in Sources */,
+				C6DF6CB71D1B159A00259F4B /* MetadataTypes.swift in Sources */,
+				C6DF6CBD1D1B159A00259F4B /* RegularExpressions.swift in Sources */,
+				C6DF6CB61D1B159A00259F4B /* Metadata.swift in Sources */,
+				C6DF6CB41D1B159A00259F4B /* PartialFormatter.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C6DF6CC71D1B18B000259F4B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C6DF6CDE1D1B18D800259F4B /* PhoneNumberKit.swift in Sources */,
+				C6DF6CDB1D1B18D800259F4B /* ParseManager.swift in Sources */,
+				C6DF6CDF1D1B18D800259F4B /* PhoneNumberParser.swift in Sources */,
+				C6DF6CD61D1B18D800259F4B /* Formatter.swift in Sources */,
+				C6DF6CDD1D1B18D800259F4B /* PhoneNumber.swift in Sources */,
+				C6DF6CD51D1B18D800259F4B /* Constants.swift in Sources */,
+				C6DF6CDC1D1B18D800259F4B /* ParseOperation.swift in Sources */,
+				C6DF6CDA1D1B18D800259F4B /* MetadataTypes.swift in Sources */,
+				C6DF6CE01D1B18D800259F4B /* RegularExpressions.swift in Sources */,
+				C6DF6CD91D1B18D800259F4B /* Metadata.swift in Sources */,
+				C6DF6CD71D1B18D800259F4B /* PartialFormatter.swift in Sources */,
+				C6DF6CD81D1B18D800259F4B /* TextField.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -452,6 +692,138 @@
 			};
 			name = Release;
 		};
+		C6DF6C501D1B09CF00259F4B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = "$(SRCROOT)/PhoneNumberKit/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_BUNDLE_IDENTIFIER = com.roymarmelstein.PhoneNumberKit.PhoneNumberKit;
+				PRODUCT_NAME = PhoneNumberKit;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		C6DF6C511D1B09CF00259F4B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = "$(SRCROOT)/PhoneNumberKit/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_BUNDLE_IDENTIFIER = com.roymarmelstein.PhoneNumberKit.PhoneNumberKit;
+				PRODUCT_NAME = PhoneNumberKit;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		C6DF6C961D1B120400259F4B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = PhoneNumberKit/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.roymarmelstein.PhoneNumberKit.PhoneNumberKit;
+				PRODUCT_NAME = PhoneNumberKit;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 2.2;
+			};
+			name = Debug;
+		};
+		C6DF6C971D1B120400259F4B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = PhoneNumberKit/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.roymarmelstein.PhoneNumberKit.PhoneNumberKit;
+				PRODUCT_NAME = PhoneNumberKit;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 2.2;
+			};
+			name = Release;
+		};
+		C6DF6CD21D1B18B000259F4B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/PhoneNumberKit/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.roymarmelstein.PhoneNumberKit.PhoneNumberKit;
+				PRODUCT_NAME = PhoneNumberKit;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.2;
+			};
+			name = Debug;
+		};
+		C6DF6CD31D1B18B000259F4B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/PhoneNumberKit/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.roymarmelstein.PhoneNumberKit.PhoneNumberKit;
+				PRODUCT_NAME = PhoneNumberKit;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.2;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -478,6 +850,33 @@
 			buildConfigurations = (
 				3424187C1BB6E5A000EE70E7 /* Debug */,
 				3424187D1BB6E5A000EE70E7 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C6DF6C521D1B09CF00259F4B /* Build configuration list for PBXNativeTarget "PhoneNumberKit-macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C6DF6C501D1B09CF00259F4B /* Debug */,
+				C6DF6C511D1B09CF00259F4B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C6DF6C981D1B120400259F4B /* Build configuration list for PBXNativeTarget "PhoneNumberKit-watchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C6DF6C961D1B120400259F4B /* Debug */,
+				C6DF6C971D1B120400259F4B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C6DF6CD11D1B18B000259F4B /* Build configuration list for PBXNativeTarget "PhoneNumberKit-tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C6DF6CD21D1B18B000259F4B /* Debug */,
+				C6DF6CD31D1B18B000259F4B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/PhoneNumberKit.xcodeproj/xcshareddata/xcschemes/PhoneNumberKit-macOS.xcscheme
+++ b/PhoneNumberKit.xcodeproj/xcshareddata/xcschemes/PhoneNumberKit-macOS.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C6DF6C4A1D1B09CF00259F4B"
+               BuildableName = "PhoneNumberKit.framework"
+               BlueprintName = "PhoneNumberKit-macOS"
+               ReferencedContainer = "container:PhoneNumberKit.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C6DF6C4A1D1B09CF00259F4B"
+            BuildableName = "PhoneNumberKit.framework"
+            BlueprintName = "PhoneNumberKit-macOS"
+            ReferencedContainer = "container:PhoneNumberKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C6DF6C4A1D1B09CF00259F4B"
+            BuildableName = "PhoneNumberKit.framework"
+            BlueprintName = "PhoneNumberKit-macOS"
+            ReferencedContainer = "container:PhoneNumberKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/PhoneNumberKit.xcodeproj/xcshareddata/xcschemes/PhoneNumberKit-tvOS.xcscheme
+++ b/PhoneNumberKit.xcodeproj/xcshareddata/xcschemes/PhoneNumberKit-tvOS.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C6DF6CCB1D1B18B000259F4B"
+               BuildableName = "PhoneNumberKit.framework"
+               BlueprintName = "PhoneNumberKit-tvOS"
+               ReferencedContainer = "container:PhoneNumberKit.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C6DF6CCB1D1B18B000259F4B"
+            BuildableName = "PhoneNumberKit.framework"
+            BlueprintName = "PhoneNumberKit-tvOS"
+            ReferencedContainer = "container:PhoneNumberKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C6DF6CCB1D1B18B000259F4B"
+            BuildableName = "PhoneNumberKit.framework"
+            BlueprintName = "PhoneNumberKit-tvOS"
+            ReferencedContainer = "container:PhoneNumberKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/PhoneNumberKit.xcodeproj/xcshareddata/xcschemes/PhoneNumberKit-watchOS.xcscheme
+++ b/PhoneNumberKit.xcodeproj/xcshareddata/xcschemes/PhoneNumberKit-watchOS.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C6DF6C901D1B120400259F4B"
+               BuildableName = "PhoneNumberKit.framework"
+               BlueprintName = "PhoneNumberKit-watchOS"
+               ReferencedContainer = "container:PhoneNumberKit.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C6DF6C901D1B120400259F4B"
+            BuildableName = "PhoneNumberKit.framework"
+            BlueprintName = "PhoneNumberKit-watchOS"
+            ReferencedContainer = "container:PhoneNumberKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C6DF6C901D1B120400259F4B"
+            BuildableName = "PhoneNumberKit.framework"
+            BlueprintName = "PhoneNumberKit-watchOS"
+            ReferencedContainer = "container:PhoneNumberKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/PhoneNumberKit/PhoneNumberKit.swift
+++ b/PhoneNumberKit/PhoneNumberKit.swift
@@ -7,8 +7,10 @@
 //
 
 import Foundation
+#if os(iOS)
 import CoreTelephony
-
+#endif
+    
 public class PhoneNumberKit: NSObject {
     
     let metadata = Metadata.sharedInstance
@@ -116,16 +118,16 @@ public class PhoneNumberKit: NSObject {
     - Returns: A computed value for the user's current region - based on the iPhone's carrier and if not available, the device region.
     */
     public func defaultRegionCode() -> String {
+#if os(iOS)
         let networkInfo = CTTelephonyNetworkInfo()
         let carrier = networkInfo.subscriberCellularProvider
         if let isoCountryCode = carrier?.isoCountryCode {
             return isoCountryCode.uppercaseString
         }
-        else {
-            let currentLocale = NSLocale.currentLocale()
-            if let countryCode = currentLocale.objectForKey(NSLocaleCountryCode) as? String {
-                return countryCode.uppercaseString
-            }
+#endif
+        let currentLocale = NSLocale.currentLocale()
+        if let countryCode = currentLocale.objectForKey(NSLocaleCountryCode) as? String {
+            return countryCode.uppercaseString
         }
         return PhoneNumberConstants.defaultCountry
     }

--- a/PhoneNumberKit/macOS/PhoneNumberKit.h
+++ b/PhoneNumberKit/macOS/PhoneNumberKit.h
@@ -1,0 +1,19 @@
+//
+//  PhoneNumberKit.h
+//  PhoneNumberKit
+//
+//  Created by Roy Marmelstein on 26/09/2015.
+//  Copyright © 2015 Roy Marmelstein. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+//! Project version number for PhoneNumberKit.
+FOUNDATION_EXPORT double PhoneNumberKitVersionNumber;
+
+//! Project version string for PhoneNumberKit.
+FOUNDATION_EXPORT const unsigned char PhoneNumberKitVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <PhoneNumberKit/PublicHeader.h>
+
+

--- a/PhoneNumberKit/watchOS/PhoneNumberKit.h
+++ b/PhoneNumberKit/watchOS/PhoneNumberKit.h
@@ -1,0 +1,19 @@
+//
+//  PhoneNumberKit.h
+//  PhoneNumberKit
+//
+//  Created by Roy Marmelstein on 26/09/2015.
+//  Copyright © 2015 Roy Marmelstein. All rights reserved.
+//
+
+#import <WatchKit/WatchKit.h>
+
+//! Project version number for PhoneNumberKit.
+FOUNDATION_EXPORT double PhoneNumberKitVersionNumber;
+
+//! Project version string for PhoneNumberKit.
+FOUNDATION_EXPORT const unsigned char PhoneNumberKitVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <PhoneNumberKit/PublicHeader.h>
+
+


### PR DESCRIPTION
With the exclusion of CoreTelephony and TextField (except on tvOS) the project compiles on macOS, watchOS and tvOS as well. Supporting these targets would be a nice addition to the list of features.