### PR TITLE
Updated for Xcode 8 beta 6

### DIFF
--- a/PhoneNumberKit.xcodeproj/project.pbxproj
+++ b/PhoneNumberKit.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		11C2EF391D62BC3200052D44 /* NSRegularExpression+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C2EF381D62BC3200052D44 /* NSRegularExpression+Swift.swift */; };
 		3420CF5E1BE8959F00FAE34F /* Formatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3420CF5D1BE8959F00FAE34F /* Formatter.swift */; };
 		3422D9BA1BE6A2D500867D02 /* ParseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3422D9B91BE6A2D500867D02 /* ParseManager.swift */; };
 		3424186F1BB6E5A000EE70E7 /* PhoneNumberKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 342418641BB6E5A000EE70E7 /* PhoneNumberKit.framework */; };
@@ -81,6 +82,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		11C2EF381D62BC3200052D44 /* NSRegularExpression+Swift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSRegularExpression+Swift.swift"; sourceTree = "<group>"; };
 		3420CF5D1BE8959F00FAE34F /* Formatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Formatter.swift; sourceTree = "<group>"; };
 		3422D9B91BE6A2D500867D02 /* ParseManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParseManager.swift; sourceTree = "<group>"; };
 		342418641BB6E5A000EE70E7 /* PhoneNumberKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PhoneNumberKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -198,6 +200,7 @@
 				346922681BC023A60023482F /* PhoneNumberKit.swift */,
 				342418811BB70F5200EE70E7 /* PhoneNumberParser.swift */,
 				34566C991BC112C500715E6B /* RegularExpressions.swift */,
+				11C2EF381D62BC3200052D44 /* NSRegularExpression+Swift.swift */,
 				3435CC8F1BBFF66F003F953B /* Resources */,
 				3420981B1BE1F1250036BBB1 /* Frameworks */,
 			);
@@ -449,6 +452,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				11C2EF391D62BC3200052D44 /* NSRegularExpression+Swift.swift in Sources */,
 				342418821BB70F5200EE70E7 /* PhoneNumberParser.swift in Sources */,
 				346922671BC01DCC0023482F /* Metadata.swift in Sources */,
 				3420CF5E1BE8959F00FAE34F /* Formatter.swift in Sources */,

--- a/PhoneNumberKit/Formatter.swift
+++ b/PhoneNumberKit/Formatter.swift
@@ -142,7 +142,7 @@ public extension PhoneNumber {
      Adjust national number for display by adding leading zero if needed. Used for basic formatting functions.
      - Returns: A string representing the adjusted national number.
      */
-    private func adjustedNationalNumber() -> String {
+    fileprivate func adjustedNationalNumber() -> String {
         if self.leadingZero == true {
             return "0" + String(nationalNumber)
         }

--- a/PhoneNumberKit/MetadataTypes.swift
+++ b/PhoneNumberKit/MetadataTypes.swift
@@ -95,7 +95,7 @@ extension MetadataTerritory {
         if let mainCountryForCode = jsondDict.value(forKey: "mainCountryForCode") as? NSString {
             self.mainCountryForCode = mainCountryForCode.boolValue
         }
-        if let availableFormats = jsondDict.value(forKey: "availableFormats")?.value(forKey: "numberFormat") {
+        if let availableFormats = (jsondDict.value(forKey: "availableFormats") as? NSDictionary)?.value(forKey: "numberFormat") {
             if let formatsArray = availableFormats as? NSArray {
                 for format in formatsArray {
                     var processedFormat = MetadataPhoneNumberFormat(jsondDict: format as? NSDictionary)

--- a/PhoneNumberKit/NSRegularExpression+Swift.swift
+++ b/PhoneNumberKit/NSRegularExpression+Swift.swift
@@ -1,0 +1,77 @@
+//
+//  NSRegularExpression+Swift.swift
+//  PhoneNumberKit
+//
+//  Created by David Beck on 8/15/16.
+//  Copyright © 2016 Roy Marmelstein. All rights reserved.
+//
+
+import Foundation
+
+
+extension String {
+	func nsRange(from range: Range<String.Index>) -> NSRange {
+		let utf16view = self.utf16
+		let from = range.lowerBound.samePosition(in: utf16view)
+		let to = range.upperBound.samePosition(in: utf16view)
+		return NSMakeRange(utf16view.distance(from: utf16view.startIndex, to: from),
+		                   utf16view.distance(from: from, to: to))
+	}
+	
+	func range(from nsRange: NSRange) -> Range<String.Index>? {
+		guard
+			let from16 = utf16.index(utf16.startIndex, offsetBy: nsRange.location, limitedBy: utf16.endIndex),
+			let to16 = utf16.index(from16, offsetBy: nsRange.length, limitedBy: utf16.endIndex),
+			let from = String.Index(from16, within: self),
+			let to = String.Index(to16, within: self)
+			else { return nil }
+		return from ..< to
+	}
+}
+
+
+extension NSRegularExpression {
+	func enumerateMatches(in string: String, options: NSRegularExpression.MatchingOptions = [], range: Range<String.Index>? = nil, using block: (NSTextCheckingResult?, NSRegularExpression.MatchingFlags, UnsafeMutablePointer<ObjCBool>) -> Swift.Void) {
+		let range = range ?? string.startIndex..<string.endIndex
+		let nsRange = string.nsRange(from: range)
+		
+		self.enumerateMatches(in: string, options: options, range: nsRange, using: block)
+	}
+	
+	func matches(in string: String, options: NSRegularExpression.MatchingOptions = [], range: Range<String.Index>? = nil) -> [NSTextCheckingResult] {
+		let range = range ?? string.startIndex..<string.endIndex
+		let nsRange = string.nsRange(from: range)
+		
+		return self.matches(in: string, options: options, range: nsRange)
+	}
+	
+	func numberOfMatches(in string: String, options: NSRegularExpression.MatchingOptions = [], range: Range<String.Index>? = nil) -> Int {
+		let range = range ?? string.startIndex..<string.endIndex
+		let nsRange = string.nsRange(from: range)
+		
+		return self.numberOfMatches(in: string, options: options, range: nsRange)
+	}
+	
+	func firstMatch(in string: String, options: NSRegularExpression.MatchingOptions = [], range: Range<String.Index>? = nil) -> NSTextCheckingResult? {
+		let range = range ?? string.startIndex..<string.endIndex
+		let nsRange = string.nsRange(from: range)
+		
+		return self.firstMatch(in: string, options: options, range: nsRange)
+	}
+	
+	func rangeOfFirstMatch(in string: String, options: NSRegularExpression.MatchingOptions = [], range: Range<String.Index>? = nil) -> Range<String.Index>? {
+		let range = range ?? string.startIndex..<string.endIndex
+		let nsRange = string.nsRange(from: range)
+		
+		let match = self.rangeOfFirstMatch(in: string, options: options, range: nsRange)
+		
+		return string.range(from: match)
+	}
+	
+	func stringByReplacingMatches(in string: String, options: NSRegularExpression.MatchingOptions = [], range: Range<String.Index>? = nil, withTemplate templ: String) -> String {
+		let range = range ?? string.startIndex..<string.endIndex
+		let nsRange = string.nsRange(from: range)
+		
+		return self.stringByReplacingMatches(in: string, options: options, range: nsRange, withTemplate: templ)
+	}
+}

--- a/PhoneNumberKit/ParseManager.swift
+++ b/PhoneNumberKit/ParseManager.swift
@@ -62,7 +62,7 @@ class ParseManager {
         }
         // National Prefix Strip (7)
         self.parser.stripNationalPrefix(&nationalNumber, metadata: regionMetadata)
-        
+		
         // Test number against general number description for correct metadata (8)
         if let generalNumberDesc = regionMetadata.generalDesc, (self.regex.hasValue(generalNumberDesc.nationalNumberPattern) == false || self.parser.isNumberMatchingDesc(nationalNumber, numberDesc: generalNumberDesc) == false) {
             throw PhoneNumberError.notANumber

--- a/PhoneNumberKit/ParseOperation.swift
+++ b/PhoneNumberKit/ParseOperation.swift
@@ -12,14 +12,14 @@ import Foundation
 Custom NSOperation for phone number parsing that supports throwing closures.
 */
 class ParseOperation<OutputType>: Operation {
-    typealias OperationClosure = (parseOp: ParseOperation<OutputType>) -> Void
-    typealias OperationThrowingClosure = (parseOp: ParseOperation<OutputType>) throws -> Void
+    typealias OperationClosure = (_ parseOp: ParseOperation<OutputType>) -> Void
+    typealias OperationThrowingClosure = (_ parseOp: ParseOperation<OutputType>) throws -> Void
     override final var isExecuting: Bool { return state == .executing }
     override final var isFinished: Bool { return state == .finished }
-    private var completionHandler: OperationClosure?
-    private var implementationHandler: OperationThrowingClosure?
-    private(set) var output: ParseOperationValue<OutputType> = .none(PhoneNumberError.generalError)
-    private var state = ParseOperationState.initial {
+    fileprivate var completionHandler: OperationClosure?
+    fileprivate var implementationHandler: OperationThrowingClosure?
+    fileprivate(set) var output: ParseOperationValue<OutputType> = .none(PhoneNumberError.generalError)
+    fileprivate var state = ParseOperationState.initial {
         willSet {
             if newValue != state {
                 willChangeValueForState(newValue)
@@ -56,7 +56,7 @@ class ParseOperation<OutputType>: Operation {
             if let implementationHandler = self.implementationHandler {
                 self.implementationHandler = nil
                 do {
-                    try implementationHandler(parseOp: self)
+                    try implementationHandler(self)
                 }
                 catch {
                     finish(with: .generalError)
@@ -135,7 +135,7 @@ extension ParseOperation {
 		guard let completionHandler = self.completionHandler else { return }
 		self.completionHandler = nil
 		self.implementationHandler = nil
-		completionHandler(parseOp: self)
+		completionHandler(self)
 		self.state = .finished
     }
 }

--- a/PhoneNumberKit/PartialFormatter.swift
+++ b/PhoneNumberKit/PartialFormatter.swift
@@ -20,7 +20,7 @@ public class PartialFormatter {
             updateMetadataForDefaultRegion()
         }
     }
-
+    
     func updateMetadataForDefaultRegion() {
         if let regionMetadata = metadata.fetchMetadataForCountry(defaultRegion) {
             defaultMetadata = metadata.fetchMainCountryMetadataForCode(regionMetadata.countryCode)
@@ -29,7 +29,7 @@ public class PartialFormatter {
         }
         currentMetadata = defaultMetadata
     }
-
+    
     var defaultMetadata: MetadataTerritory?
     var currentMetadata: MetadataTerritory?
     var prefixBeforeNationalNumber =  String()
@@ -38,21 +38,21 @@ public class PartialFormatter {
     var withPrefix = true
     
     //MARK: Status
-
+    
     public var currentRegion: String {
         get {
             return currentMetadata?.codeID ?? defaultRegion
         }
     }
-  
+    
     
     //MARK: Lifecycle
     
     /**
-    Initialise a partial formatter with the default region
-    
-    - returns: PartialFormatter object
-    */
+     Initialise a partial formatter with the default region
+     
+     - returns: PartialFormatter object
+     */
     public convenience init() {
         let defaultRegion = PhoneNumberKit().defaultRegionCode()
         self.init(defaultRegion: defaultRegion)
@@ -92,7 +92,7 @@ public class PartialFormatter {
             nationalNumber = extractCountryCallingCode(nationalNumber)
         }
         nationalNumber = extractNationalPrefix(nationalNumber)
-
+        
         if let formats = availableFormats(nationalNumber) {
             if let formattedNumber = applyFormat(nationalNumber, formats: formats) {
                 nationalNumber = formattedNumber
@@ -119,7 +119,7 @@ public class PartialFormatter {
         if finalNumber.characters.last == PhoneNumberConstants.separatorBeforeNationalNumber.characters.first {
             finalNumber = finalNumber.substring(to: finalNumber.index(before: finalNumber.endIndex))
         }
-
+        
         return finalNumber
     }
     
@@ -135,7 +135,7 @@ public class PartialFormatter {
     
     internal func isValidRawNumber(_ rawNumber: String) -> Bool {
         do {
-            // In addition to validPhoneNumberPattern, 
+            // In addition to validPhoneNumberPattern,
             // accept any sequence of digits and whitespace, prefixed or not by a plus sign
             let validPartialPattern = "[+＋]?(\\s*\\d)+\\s*$|\(PhoneNumberPatterns.validPhoneNumberPattern)"
             let validNumberMatches = try regex.regexMatches(validPartialPattern, string: rawNumber)
@@ -151,10 +151,11 @@ public class PartialFormatter {
     }
     
     internal func isNanpaNumberWithNationalPrefix(_ rawNumber: String) -> Bool {
-        if currentMetadata?.countryCode != 1 {
-            return false
-        }
-        return (rawNumber.characters.first == "1" && String(rawNumber.characters.index(rawNumber.characters.startIndex, offsetBy: 1)) != "0" && String(rawNumber.characters.index(rawNumber.characters.startIndex, offsetBy: 1)) != "1")
+        guard currentMetadata?.countryCode == 1 && rawNumber.characters.count > 1 else { return false }
+        
+        let firstCharacter = rawNumber.characters.first
+        let secondCharacter = rawNumber.characters[rawNumber.characters.index(rawNumber.characters.startIndex, offsetBy: 1)]
+        return (firstCharacter == "1" && secondCharacter != "0" && secondCharacter != "1")
     }
     
     func isFormatEligible(_ format: MetadataPhoneNumberFormat) -> Bool {
@@ -211,7 +212,7 @@ public class PartialFormatter {
             }
             catch {
                 return processedNumber
-                }
+            }
         }
         let index = rawNumber.characters.index(rawNumber.startIndex, offsetBy: startOfNationalNumber)
         processedNumber = rawNumber.substring(from: index)
@@ -236,13 +237,13 @@ public class PartialFormatter {
             prefixBeforeNationalNumber.append(" ")
         }
         else if withPrefix == false && prefixBeforeNationalNumber.isEmpty {
-            let potentialCountryCodeString = String(currentMetadata?.countryCode)
+            let potentialCountryCodeString = String(describing: currentMetadata?.countryCode)
             prefixBeforeNationalNumber.append(potentialCountryCodeString)
             prefixBeforeNationalNumber.append(" ")
         }
         return processedNumber
     }
-
+    
     func availableFormats(_ rawNumber: String) -> [MetadataPhoneNumberFormat]? {
         var tempPossibleFormats = [MetadataPhoneNumberFormat]()
         var possibleFormats = [MetadataPhoneNumberFormat]()
@@ -291,7 +292,7 @@ public class PartialFormatter {
                     }
                 }
                 catch {
-                
+                    
                 }
             }
         }
@@ -309,14 +310,10 @@ public class PartialFormatter {
         }
         do {
             let characterClassRegex = try regex.regexWithPattern(PhoneNumberPatterns.characterClassPattern)
-            var nsString = numberPattern as NSString
-            var stringRange = NSMakeRange(0, nsString.length)
-            numberPattern = characterClassRegex.stringByReplacingMatches(in: numberPattern, options: [], range: stringRange, withTemplate: "\\\\d")
-    
+            numberPattern = characterClassRegex.stringByReplacingMatches(in: numberPattern, withTemplate: "\\\\d")
+            
             let standaloneDigitRegex = try regex.regexWithPattern(PhoneNumberPatterns.standaloneDigitPattern)
-            nsString = numberPattern as NSString
-            stringRange = NSMakeRange(0, nsString.length)
-            numberPattern = standaloneDigitRegex.stringByReplacingMatches(in: numberPattern, options: [], range: stringRange, withTemplate: "\\\\d")
+            numberPattern = standaloneDigitRegex.stringByReplacingMatches(in: numberPattern, withTemplate: "\\\\d")
             
             if let tempTemplate = getFormattingTemplate(numberPattern, numberFormat: numberFormat, rawNumber: rawNumber) {
                 if let nationalPrefixFormattingRule = format.nationalPrefixFormattingRule {
@@ -346,7 +343,7 @@ public class PartialFormatter {
             }
         }
         catch {
-        
+            
         }
         return nil
     }
@@ -364,7 +361,7 @@ public class PartialFormatter {
             }
             else {
                 if rebuiltIndex < rawNumber.characters.count {
-                rebuiltString.append(character)
+                    rebuiltString.append(character)
                 }
             }
         }
@@ -374,7 +371,7 @@ public class PartialFormatter {
             rebuiltString.append(remainingNationalNumber)
         }
         rebuiltString = rebuiltString.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
-
+        
         return rebuiltString
     }
     

--- a/PhoneNumberKit/PhoneNumberKit.swift
+++ b/PhoneNumberKit/PhoneNumberKit.swift
@@ -127,10 +127,10 @@ public class PhoneNumberKit: NSObject {
 #endif
         let currentLocale = Locale.current
         if #available(iOS 10.0, *) {
-            let countryCode = currentLocale.countryCode
-            return countryCode.uppercased()
+            let countryCode = currentLocale.regionCode
+            return countryCode?.uppercased() ?? ""
         } else {
-            if let countryCode = currentLocale.object(forKey: .countryCode) as? String {
+			if let countryCode = (currentLocale as NSLocale).object(forKey: .countryCode) as? String {
                 return countryCode.uppercased()
             }
         }

--- a/PhoneNumberKit/PhoneNumberParser.swift
+++ b/PhoneNumberKit/PhoneNumberParser.swift
@@ -62,7 +62,7 @@ class PhoneNumberParser {
                     return 0
                 }
                 stripNationalPrefix(&potentialNationalNumber, metadata: metadata)
-                let potentialNationalNumberStr = String(potentialNationalNumber.copy())
+                let potentialNationalNumberStr = potentialNationalNumber
                 if ((!regex.matchesEntirely(validNumberPattern, string: fullNumber) && regex.matchesEntirely(validNumberPattern, string: potentialNationalNumberStr )) || regex.testStringLengthAgainstPattern(possibleNumberPattern, string: fullNumber as String) == false) {
                     nationalNumber = potentialNationalNumberStr
                     if let countryCode = UInt64(defaultCountryCode) {
@@ -200,15 +200,14 @@ class PhoneNumberParser {
     func parsePrefixAsIdd(_ number: inout String, iddPattern: String) -> Bool {
         if (regex.stringPositionByRegex(iddPattern, string: number) == 0) {
             do {
-                let nsString = number as NSString
                 guard let matched = try regex.regexMatches(iddPattern as String, string: number as String).first else {
                     return false
                 }
-                let matchedString = number.substringWithNSRange(matched.range)
+                let matchedString = number.substring(with: matched.range)
                 let matchEnd = matchedString.characters.count
-                let remainString: NSString = nsString.substring(from: matchEnd)
+                let remainString = (number as NSString).substring(from: matchEnd)
                 let capturingDigitPatterns = try NSRegularExpression(pattern: PhoneNumberPatterns.capturingDigitPattern, options: NSRegularExpression.Options.caseInsensitive)
-                let matchedGroups = capturingDigitPatterns.matches(in: remainString as String, options: [], range: NSMakeRange(0, remainString.length))
+                let matchedGroups = capturingDigitPatterns.matches(in: remainString as String)
                 if let firstMatch = matchedGroups.first {
                     let digitMatched = remainString.substring(with: firstMatch.range) as NSString
                     if digitMatched.length > 0 {
@@ -240,9 +239,9 @@ class PhoneNumberParser {
             let matches = try regex.regexMatches(PhoneNumberPatterns.extnPattern, string: number)
             if let match = matches.first {
                 let adjustedRange = NSMakeRange(match.range.location + 1, match.range.length - 1)
-                let matchString = number.substringWithNSRange(adjustedRange)
+                let matchString = number.substring(with: adjustedRange)
                 let stringRange = NSMakeRange(0, match.range.location)
-                number = number.substringWithNSRange(stringRange)
+                number = number.substring(with: stringRange)
                 return matchString
             }
             return nil
@@ -291,11 +290,11 @@ class PhoneNumberParser {
             let matches = try regex.regexMatches(prefixPattern, string: number)
             if let firstMatch = matches.first {
                 let nationalNumberRule = metadata.generalDesc?.nationalNumberPattern
-                let firstMatchString = number.substringWithNSRange(firstMatch.range)
+                let firstMatchString = number.substring(with: firstMatch.range)
                 let numOfGroups = firstMatch.numberOfRanges - 1
                 var transformedNumber: String = String()
                 let firstRange = firstMatch.rangeAt(numOfGroups)
-                let firstMatchStringWithGroup = (firstRange.location != NSNotFound && firstRange.location < number.characters.count) ? number.substringWithNSRange(firstRange):  String()
+                let firstMatchStringWithGroup = (firstRange.location != NSNotFound && firstRange.location < number.characters.count) ? number.substring(with: firstRange):  String()
                 let firstMatchStringWithGroupHasValue = regex.hasValue(firstMatchStringWithGroup)
                 if let transformRule = metadata.nationalPrefixTransformRule , firstMatchStringWithGroupHasValue == true {
                     transformedNumber = regex.replaceFirstStringByRegex(prefixPattern, string: number, templateString: transformRule)

--- a/PhoneNumberKit/RegularExpressions.swift
+++ b/PhoneNumberKit/RegularExpressions.swift
@@ -58,10 +58,7 @@ class RegularExpressions {
         do {
             let internalString = string
             let currentPattern =  try regexWithPattern(pattern)
-            // NSRegularExpression accepts Swift strings but works with NSString under the hood. Safer to bridge to NSString for taking range.
-            let nsString = internalString as NSString
-            let stringRange = NSMakeRange(0, nsString.length)
-            let matches = currentPattern.matches(in: internalString, options: [], range: stringRange)
+            let matches = currentPattern.matches(in: internalString)
             return matches
         }
         catch {
@@ -70,9 +67,7 @@ class RegularExpressions {
     }
     
     func phoneDataDetectorMatches(_ string: String) throws -> [NSTextCheckingResult] {
-        let nsString = string as NSString
-        let stringRange = NSMakeRange(0, nsString.length)
-        guard let matches = phoneDataDetector?.matches(in: string, options: [], range: stringRange) else {
+        guard let matches = phoneDataDetector?.matches(in: string) else {
             throw PhoneNumberError.generalError
         }
         if matches.isEmpty == false {
@@ -144,7 +139,7 @@ class RegularExpressions {
             let matches = try regexMatches(pattern, string: string)
             var matchedStrings = [String]()
             for match in matches {
-                let processedString = string.substringWithNSRange(match.range)
+                let processedString = string.substring(with: match.range)
                 matchedStrings.append(processedString)
             }
             return matchedStrings
@@ -160,20 +155,16 @@ class RegularExpressions {
         do {
             var replacementResult = string
             let regex =  try regexWithPattern(pattern)
-            // NSRegularExpression accepts Swift strings but works with NSString under the hood. Safer to bridge to NSString for taking range.
-            let nsString = string as NSString
-            let stringRange = NSMakeRange(0, nsString.length)
-            let matches = regex.matches(in: string,
-                options: [], range: stringRange)
+            let matches = regex.matches(in: string)
             if matches.count == 1 {
-                let range = regex.rangeOfFirstMatch(in: string, options: [], range: stringRange)
-                if range.location != NSNotFound {
+                let range = regex.rangeOfFirstMatch(in: string)
+                if range != nil {
                     replacementResult = regex.stringByReplacingMatches(in: string, options: [], range: range, withTemplate: "")
                 }
                 return replacementResult
             }
             else if matches.count > 1 {
-                replacementResult = regex.stringByReplacingMatches(in: string, options: [], range: stringRange, withTemplate: "")
+                replacementResult = regex.stringByReplacingMatches(in: string, withTemplate: "")
             }
             return replacementResult
         } catch {
@@ -185,20 +176,16 @@ class RegularExpressions {
         do {
             var replacementResult = string
             let regex =  try regexWithPattern(pattern)
-            // NSRegularExpression accepts Swift strings but works with NSString under the hood. Safer to bridge to NSString for taking range.
-            let nsString = string as NSString
-            let stringRange = NSMakeRange(0, nsString.length)
-            let matches = regex.matches(in: string,
-                options: [], range: stringRange)
+            let matches = regex.matches(in: string)
             if matches.count == 1 {
-                let range = regex.rangeOfFirstMatch(in: string, options: [], range: stringRange)
-                if range.location != NSNotFound {
+                let range = regex.rangeOfFirstMatch(in: string)
+                if range != nil {
                     replacementResult = regex.stringByReplacingMatches(in: string, options: [], range: range, withTemplate: template)
                 }
                 return replacementResult
             }
             else if matches.count > 1 {
-                replacementResult = regex.stringByReplacingMatches(in: string, options: [], range: stringRange, withTemplate: template)
+                replacementResult = regex.stringByReplacingMatches(in: string, withTemplate: template)
             }
             return replacementResult
         } catch {
@@ -208,15 +195,12 @@ class RegularExpressions {
     
     func replaceFirstStringByRegex(_ pattern: String, string: String, templateString: String) -> String {
         do {
-            // NSRegularExpression accepts Swift strings but works with NSString under the hood. Safer to bridge to NSString for taking range.
-            var nsString = string as NSString
-            let stringRange = NSMakeRange(0, nsString.length)
             let regex = try regexWithPattern(pattern)
-            let range = regex.rangeOfFirstMatch(in: string, options: [], range: stringRange)
-            if range.location != NSNotFound {
-                nsString = regex.stringByReplacingMatches(in: string, options: [], range: range, withTemplate: templateString)
+            let range = regex.rangeOfFirstMatch(in: string)
+            if range != nil {
+                return regex.stringByReplacingMatches(in: string, options: [], range: range, withTemplate: templateString)
             }
-            return nsString as String
+            return string
         } catch {
             return String()
         }
@@ -236,7 +220,7 @@ class RegularExpressions {
     
     // MARK: Validations
     
-    func hasValue(_ value: NSString?) -> Bool {
+    func hasValue(_ value: String?) -> Bool {
         if let valueString = value {
             if valueString.trimmingCharacters(in: spaceCharacterSet).characters.count == 0 {
                 return false
@@ -264,7 +248,7 @@ class RegularExpressions {
 // MARK: Extensions
 
 extension String {
-    func substringWithNSRange(_ range: NSRange) -> String {
+    func substring(with range: NSRange) -> String {
         let nsString = self as NSString
         return nsString.substring(with: range)
     }

--- a/PhoneNumberKit/UI/TextField.swift
+++ b/PhoneNumberKit/UI/TextField.swift
@@ -126,8 +126,8 @@ public class PhoneNumberTextField: UITextField, UITextFieldDelegate {
         // Look for the next valid number after the cursor, when found return a CursorPosition struct
         for i in cursorEnd ..< textAsNSString.length  {
             let cursorRange = NSMakeRange(i, 1)
-            let candidateNumberAfterCursor: NSString = textAsNSString.substring(with: cursorRange)
-            if (candidateNumberAfterCursor.rangeOfCharacter(from: nonNumericSet).location == NSNotFound) {
+            let candidateNumberAfterCursor = textAsNSString.substring(with: cursorRange)
+            if candidateNumberAfterCursor.rangeOfCharacter(from: nonNumericSet) != nil {
                 for j in cursorRange.location ..< textAsNSString.length  {
                     let candidateCharacter = textAsNSString.substring(with: NSMakeRange(j, 1))
                     if candidateCharacter == candidateNumberAfterCursor {


### PR DESCRIPTION
There are actually some larger changes in here motivated by changes in the latest beta of Swift 3. For instance, calling a method on an `NSString` using an `NSRange` now returns a regular Swift `String`. This leads to some really weird code. Instead, I opted to include String.Index based methods on `NSRegularExpression` that make using it much simpler with plain Swift strings.