### PR TITLE
Ensure convenience initialization works

### DIFF
--- a/PhoneNumberKit/PartialFormatter.swift
+++ b/PhoneNumberKit/PartialFormatter.swift
@@ -11,20 +11,22 @@ import Foundation
 /// Partial formatter
 public class PartialFormatter {
     
+    private let phoneNumberKit: PhoneNumberKit
+
     weak var metadataManager: MetadataManager?
     weak var parser: PhoneNumberParser?
     weak var regexManager: RegexManager?
     
     public convenience init() {
-        let phoneNumberKit = PhoneNumberKit()
-        self.init(phoneNumberKit: phoneNumberKit, defaultRegion: PhoneNumberKit.defaultRegionCode())
+        self.init(defaultRegion: PhoneNumberKit.defaultRegionCode())
     }
 
-    public convenience init(phoneNumberKit: PhoneNumberKit, defaultRegion: String, withPrefix: Bool = true) {
-        self.init(regexManager: phoneNumberKit.regexManager, metadataManager: phoneNumberKit.metadataManager, parser: phoneNumberKit.parseManager.parser, defaultRegion: defaultRegion, withPrefix: withPrefix)
+    public convenience init(phoneNumberKit: PhoneNumberKit = PhoneNumberKit(), defaultRegion: String, withPrefix: Bool = true) {
+        self.init(phoneNumberKit: phoneNumberKit, regexManager: phoneNumberKit.regexManager, metadataManager: phoneNumberKit.metadataManager, parser: phoneNumberKit.parseManager.parser, defaultRegion: defaultRegion, withPrefix: withPrefix)
     }
     
-    init(regexManager: RegexManager, metadataManager: MetadataManager, parser: PhoneNumberParser, defaultRegion: String, withPrefix: Bool = true) {
+    init(phoneNumberKit: PhoneNumberKit, regexManager: RegexManager, metadataManager: MetadataManager, parser: PhoneNumberParser, defaultRegion: String, withPrefix: Bool = true) {
+        self.phoneNumberKit = phoneNumberKit
         self.regexManager = regexManager
         self.metadataManager = metadataManager
         self.parser = parser

--- a/PhoneNumberKitTests/PartialFormatterTests.swift
+++ b/PhoneNumberKitTests/PartialFormatterTests.swift
@@ -296,5 +296,13 @@ class PartialFormatterTests: XCTestCase {
         _ = partialFormatter.formatPartial("invalid raw number")
         XCTAssertEqual(partialFormatter.currentRegion, "DE")
     }
+
+    // MARK: convenience initializer
+    func testConvenienceInitializerAllowsFormatting() {
+        let partialFormatter = PartialFormatter()
+
+        let testNumber = "8675309"
+        XCTAssertEqual(partialFormatter.formatPartial(testNumber), "867-5309")
+    }
 }
 


### PR DESCRIPTION
We need to ensure that an instance of a PhoneNumberKit class is strongly referenced when creating a PartialFormatter, otherwise the weakly held properties will become nil, and formatting will fail. Allow for a default initialized parameter allows for all existing initialization sequences to work as they did before while allowing for convenience initialized PartialFormatters to work as well.