### PR TITLE
Added getLeadingDigits (mobile) method

### DIFF
--- a/PhoneNumberKit/PhoneNumberKit.swift
+++ b/PhoneNumberKit/PhoneNumberKit.swift
@@ -125,6 +125,16 @@ public class PhoneNumberKit: NSObject {
         return results
     }
     
+    /// Get leading digits for compliant region code
+    ///
+    /// - parameter country: ISO 639 compliant region code.
+    ///
+    /// - returns: leading digits (e.g. 876 for Jamaica).
+    public func getLeadingDigits(for country: String) -> String? {
+        let leadingDigits = metadataManager.filterTerritories(byCountry: country)?.leadingDigits
+        return leadingDigits
+    }
+    
     /// Determine the region code of a given phone number.
     ///
     /// - parameter phoneNumber: PhoneNumber object


### PR DESCRIPTION
If you want to add mobile numbers to +1 you need this method. Return bad value for "DO" and "PR" codes.