### PR TITLE
Fixes building from carthage for app extension

### DIFF
--- a/PhoneNumberKit.xcodeproj/project.pbxproj
+++ b/PhoneNumberKit.xcodeproj/project.pbxproj
@@ -651,6 +651,7 @@
 		342418791BB6E5A000EE70E7 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
@@ -671,6 +672,7 @@
 		3424187A1BB6E5A000EE70E7 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
If an app extension links to `PhoneNumberKit` it gets a 
warning "linking against a dylib which is not safe for use in application extensions".