### PR TITLE
add isPartialFormatterEnabled check for PhoneNumberTextField

### DIFF
--- a/PhoneNumberKit/UI/TextField.swift
+++ b/PhoneNumberKit/UI/TextField.swift
@@ -32,6 +32,7 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
             }
         }
     }
+    public var isPartialFormatterEnabled = true
     
     
     let partialFormatter: PartialFormatter
@@ -174,6 +175,9 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
         // allow delegate to intervene
         guard _delegate?.textField?(textField, shouldChangeCharactersIn: range, replacementString: string) ?? true else {
             return false
+        }
+        guard isPartialFormatterEnabled else {
+            return true
         }
         
         let textAsNSString = text as NSString


### PR DESCRIPTION
I want to disable and enable PhoneNumberTextField's parsing and changeCharacters behavior frequently, how can I do this? 

I connot do this with delegate check:
```
// allow delegate to intervene
        guard _delegate?.textField?(textField, shouldChangeCharactersIn: range, replacementString: string) ?? true else {
            return false
        }
```
Can you accept this pull request， or any other way to do that?