### PR TITLE
Tighten scope on the 'formatter' variable

### DIFF
--- a/PhoneNumberKit/PhoneNumberKit.swift
+++ b/PhoneNumberKit/PhoneNumberKit.swift
@@ -58,7 +58,6 @@ public class PhoneNumberKit: NSObject {
     ///
     /// - returns: Formatted representation of the PhoneNumber.
     public func format(_ phoneNumber: PhoneNumber, toType formatType:PhoneNumberFormat, withPrefix prefix: Bool = true) -> String {
-        let formatter = Formatter(phoneNumberKit: self)
         if formatType == .e164 {
             let formattedNationalNumber = phoneNumber.adjustedNationalNumber()
             if prefix == false {
@@ -66,6 +65,7 @@ public class PhoneNumberKit: NSObject {
             }
             return "+\(phoneNumber.countryCode)\(formattedNationalNumber)"
         } else {
+            let formatter = Formatter(phoneNumberKit: self)
             let regionMetadata = metadataManager.mainTerritoryByCode[phoneNumber.countryCode]
             let formattedNationalNumber = formatter.format(phoneNumber: phoneNumber, formatType: formatType, regionMetadata: regionMetadata)
             if formatType == .international && prefix == true {


### PR DESCRIPTION
## Why?
I'm doing parsing + e.164 formatting in a tight loop -- this extra allocation doesn't likely hurt a lot, but I figure why incur it if we don't have to?

## What Changed?
Move the `formatter` variable creation inside the scope where it is used, so it is not created if it will not be used.