### PR TITLE
Test must not made any assumption about the current locale.

### DIFF
--- a/PhoneNumberKitTests/PartialFormatterTests.swift
+++ b/PhoneNumberKitTests/PartialFormatterTests.swift
@@ -299,7 +299,7 @@ class PartialFormatterTests: XCTestCase {
 
     // MARK: convenience initializer
     func testConvenienceInitializerAllowsFormatting() {
-        let partialFormatter = PartialFormatter()
+        let partialFormatter = PartialFormatter(defaultRegion: "US")
 
         let testNumber = "8675309"
         XCTAssertEqual(partialFormatter.formatPartial(testNumber), "867-5309")

--- a/PhoneNumberKitTests/PhoneNumberKitParsingTests.swift
+++ b/PhoneNumberKitTests/PhoneNumberKitParsingTests.swift
@@ -43,7 +43,7 @@ class PhoneNumberKitParsingTests: XCTestCase {
             XCTAssertTrue(phoneNumberNationalFormat1 == "(650) 253-0000")
             let phoneNumberE164Format1 = phoneNumberKit.format(phoneNumber1, toType: .e164, withPrefix: false)
             XCTAssertTrue(phoneNumberE164Format1 == "6502530000")
-            let phoneNumber2 = try phoneNumberKit.parse("800 253 0000")
+            let phoneNumber2 = try phoneNumberKit.parse("800 253 0000", withRegion: "US")
             XCTAssertNotNil(phoneNumber2)
             let phoneNumberInternationalFormat2 = phoneNumberKit.format(phoneNumber2, toType: .international, withPrefix: false)
             XCTAssertTrue(phoneNumberInternationalFormat2 == "800-253-0000")
@@ -67,7 +67,7 @@ class PhoneNumberKitParsingTests: XCTestCase {
             XCTAssertTrue(phoneNumberNationalFormat1 == "(650) 253-0000")
             let phoneNumberE164Format1 = phoneNumberKit.format(phoneNumber1, toType: .e164)
             XCTAssertTrue(phoneNumberE164Format1 == "+16502530000")
-            let phoneNumber2 = try phoneNumberKit.parse("800 253 0000")
+            let phoneNumber2 = try phoneNumberKit.parse("800 253 0000", withRegion: "US")
             XCTAssertNotNil(phoneNumber2)
             let phoneNumberInternationalFormat2 = phoneNumberKit.format(phoneNumber2, toType: .international)
             XCTAssertTrue(phoneNumberInternationalFormat2 == "+1 800-253-0000")
@@ -75,7 +75,7 @@ class PhoneNumberKitParsingTests: XCTestCase {
             XCTAssertTrue(phoneNumberNationalFormat2 == "(800) 253-0000")
             let phoneNumberE164Format2 = phoneNumberKit.format(phoneNumber2, toType: .e164)
             XCTAssertTrue(phoneNumberE164Format2 == "+18002530000")
-            let phoneNumber3 = try phoneNumberKit.parse("900 253 0000")
+            let phoneNumber3 = try phoneNumberKit.parse("900 253 0000", withRegion: "US")
             XCTAssertNotNil(phoneNumber3)
             let phoneNumberInternationalFormat3 = phoneNumberKit.format(phoneNumber3, toType: .international)
             XCTAssertTrue(phoneNumberInternationalFormat3 == "+1 900-253-0000")
@@ -273,7 +273,7 @@ class PhoneNumberKitParsingTests: XCTestCase {
     }
 
     func testUSTollFreeNumberType() {
-        guard let number = try? phoneNumberKit.parse("8002345678") else {
+        guard let number = try? phoneNumberKit.parse("8002345678", withRegion: "US") else {
             XCTFail()
             return
         }

--- a/PhoneNumberKitTests/PhoneNumberKitTests.swift
+++ b/PhoneNumberKitTests/PhoneNumberKitTests.swift
@@ -228,7 +228,7 @@ class PhoneNumberKitTests: XCTestCase {
     func testValidNumberWithAmericanIDDNoWhiteSpace() {
         let testNumber = "011447739555555"
         do {
-            let phoneNumber = try phoneNumberKit.parse(testNumber)
+            let phoneNumber = try phoneNumberKit.parse(testNumber, withRegion: "US")
             XCTAssertEqual(phoneNumberKit.format(phoneNumber, toType: .e164), "+447739555555")
             XCTAssertEqual(phoneNumber.countryCode, 44)
             XCTAssertEqual(phoneNumber.nationalNumber, 7739555555)
@@ -243,7 +243,7 @@ class PhoneNumberKitTests: XCTestCase {
     func testValidNumberWithAmericanIDDWhiteSpace() {
         let testNumber = "01155 11 9 6 555 55 55"
         do {
-            let phoneNumber = try phoneNumberKit.parse(testNumber)
+            let phoneNumber = try phoneNumberKit.parse(testNumber, withRegion: "US")
             XCTAssertEqual(phoneNumberKit.format(phoneNumber, toType: .e164), "+5511965555555")
             XCTAssertEqual(phoneNumber.countryCode, 55)
             XCTAssertEqual(phoneNumber.nationalNumber, 11965555555)
@@ -258,7 +258,7 @@ class PhoneNumberKitTests: XCTestCase {
     func testValidLocalNumberWithNoPrefixNoWhiteSpace() {
         let testNumber = "2015555555"
         do {
-            let phoneNumber = try phoneNumberKit.parse(testNumber)
+            let phoneNumber = try phoneNumberKit.parse(testNumber, withRegion: "US")
             XCTAssertEqual(phoneNumberKit.format(phoneNumber, toType: .e164), "+12015555555")
             XCTAssertEqual(phoneNumber.countryCode, 1)
             XCTAssertEqual(phoneNumber.nationalNumber, 2015555555)
@@ -273,7 +273,7 @@ class PhoneNumberKitTests: XCTestCase {
     func testValidLocalNumberWithNoPrefixWhiteSpace() {
         let testNumber = "500-2-55-555-5"
         do {
-            let phoneNumber = try phoneNumberKit.parse(testNumber)
+            let phoneNumber = try phoneNumberKit.parse(testNumber, withRegion: "US")
             XCTAssertEqual(phoneNumberKit.format(phoneNumber, toType: .e164), "+15002555555")
             XCTAssertEqual(phoneNumber.countryCode, 1)
             XCTAssertEqual(phoneNumber.nationalNumber, 5002555555)


### PR DESCRIPTION
Fix running test on device with default Locale to something else than US.
A number of tests rely on the fact that the default locale is US and fail if this is something else.
Fix that issue by always providing explicit locale in tests.
