### PR TITLE
Add a new live Formatter class based on Foundation NSFormatter.

### DIFF
--- a/PhoneNumberKit.xcodeproj/project.pbxproj
+++ b/PhoneNumberKit.xcodeproj/project.pbxproj
@@ -11,6 +11,10 @@
 		1B80904E2300B4DC006AE849 /* MetadataParsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3417BD6A2210AC4900477EE7 /* MetadataParsing.swift */; };
 		1B80904F2300B4DC006AE849 /* MetadataParsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3417BD6A2210AC4900477EE7 /* MetadataParsing.swift */; };
 		1B8090502300B4DD006AE849 /* MetadataParsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3417BD6A2210AC4900477EE7 /* MetadataParsing.swift */; };
+		1B0651171E2AD698006AE849 /* PhoneNumberFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B0651161E2AD698006AE849 /* PhoneNumberFormatter.swift */; };
+		1B1A4DD723007580006AE849 /* PhoneNumberFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B0651161E2AD698006AE849 /* PhoneNumberFormatter.swift */; };
+		1B1A4DD82300759E006AE849 /* PhoneNumberFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B0651161E2AD698006AE849 /* PhoneNumberFormatter.swift */; };
+		1B1A4DD9230075A6006AE849 /* PhoneNumberFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B0651161E2AD698006AE849 /* PhoneNumberFormatter.swift */; };
 		3417BD6B2210AC4900477EE7 /* MetadataParsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3417BD6A2210AC4900477EE7 /* MetadataParsing.swift */; };
 		3420CF5E1BE8959F00FAE34F /* Formatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3420CF5D1BE8959F00FAE34F /* Formatter.swift */; };
 		3422D9BA1BE6A2D500867D02 /* ParseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3422D9B91BE6A2D500867D02 /* ParseManager.swift */; };
@@ -86,6 +90,7 @@
 
 /* Begin PBXFileReference section */
 		11C2EF381D62BC3200052D44 /* NSRegularExpression+Swift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSRegularExpression+Swift.swift"; sourceTree = "<group>"; };
+		1B0651161E2AD698006AE849 /* PhoneNumberFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhoneNumberFormatter.swift; sourceTree = "<group>"; };
 		3417BD6A2210AC4900477EE7 /* MetadataParsing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataParsing.swift; sourceTree = "<group>"; };
 		3420CF5D1BE8959F00FAE34F /* Formatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Formatter.swift; sourceTree = "<group>"; };
 		3422D9B91BE6A2D500867D02 /* ParseManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParseManager.swift; sourceTree = "<group>"; };
@@ -211,6 +216,7 @@
 				343B850A1C62A25600918E46 /* PartialFormatter.swift */,
 				343B850B1C62A25600918E46 /* TextField.swift */,
 				342418811BB70F5200EE70E7 /* PhoneNumberParser.swift */,
+				1B0651161E2AD698006AE849 /* PhoneNumberFormatter.swift */,
 				11C2EF381D62BC3200052D44 /* NSRegularExpression+Swift.swift */,
 				3435CC8F1BBFF66F003F953B /* Resources */,
 				3420981B1BE1F1250036BBB1 /* Frameworks */,
@@ -477,6 +483,7 @@
 				3422D9BA1BE6A2D500867D02 /* ParseManager.swift in Sources */,
 				34566C9A1BC112C500715E6B /* RegexManager.swift in Sources */,
 				342418801BB705B500EE70E7 /* PhoneNumber.swift in Sources */,
+				1B0651171E2AD698006AE849 /* PhoneNumberFormatter.swift in Sources */,
 				34AA66021BDD160B00467912 /* Constants.swift in Sources */,
 				342548F01BE7EED500FBE524 /* MetadataTypes.swift in Sources */,
 			);
@@ -500,6 +507,7 @@
 				C6B53DA71D94508400E607DD /* NSRegularExpression+Swift.swift in Sources */,
 				C6DF6C5A1D1B09DD00259F4B /* ParseManager.swift in Sources */,
 				C6DF6C5E1D1B09DD00259F4B /* PhoneNumberParser.swift in Sources */,
+				1B1A4DD723007580006AE849 /* PhoneNumberFormatter.swift in Sources */,
 				C6DF6C551D1B09DD00259F4B /* Formatter.swift in Sources */,
 				1B80904E2300B4DC006AE849 /* MetadataParsing.swift in Sources */,
 				C6DF6C5C1D1B09DD00259F4B /* PhoneNumber.swift in Sources */,
@@ -519,6 +527,7 @@
 				C6B53DA51D944F8000E607DD /* NSRegularExpression+Swift.swift in Sources */,
 				C6DF6CB81D1B159A00259F4B /* ParseManager.swift in Sources */,
 				C6DF6CBC1D1B159A00259F4B /* PhoneNumberParser.swift in Sources */,
+				1B1A4DD9230075A6006AE849 /* PhoneNumberFormatter.swift in Sources */,
 				C6DF6CB31D1B159A00259F4B /* Formatter.swift in Sources */,
 				1B80904F2300B4DC006AE849 /* MetadataParsing.swift in Sources */,
 				C6DF6CBA1D1B159A00259F4B /* PhoneNumber.swift in Sources */,
@@ -545,6 +554,7 @@
 				C6DF6CDA1D1B18D800259F4B /* MetadataTypes.swift in Sources */,
 				C6DF6CE01D1B18D800259F4B /* RegexManager.swift in Sources */,
 				C6DF6CD91D1B18D800259F4B /* MetadataManager.swift in Sources */,
+				1B1A4DD82300759E006AE849 /* PhoneNumberFormatter.swift in Sources */,
 				C6DF6CD71D1B18D800259F4B /* PartialFormatter.swift in Sources */,
 				C6DF6CD81D1B18D800259F4B /* TextField.swift in Sources */,
 			);

--- a/PhoneNumberKit/PhoneNumberFormatter.swift
+++ b/PhoneNumberKit/PhoneNumberFormatter.swift
@@ -1,0 +1,222 @@
+//
+//  PhoneNumberFormatter.swift
+//  PhoneNumberKit
+//
+//  Created by Jean-Daniel.
+//  Copyright © 2019 Xenonium. All rights reserved.
+//
+
+import Foundation
+
+open class PhoneNumberFormatter : Foundation.Formatter {
+
+  public let phoneNumberKit : PhoneNumberKit
+
+  private let partialFormatter: PartialFormatter
+
+  // We declare all properties as @objc, so we can configure them though IB (using custom property)
+  @objc dynamic
+  public var generatesPhoneNumber = false
+
+  /// Override region to set a custom region. Automatically uses the default region code.
+  @objc dynamic
+  public var defaultRegion = PhoneNumberKit.defaultRegionCode() {
+    didSet {
+      partialFormatter.defaultRegion = defaultRegion
+    }
+  }
+
+  @objc dynamic
+  public var withPrefix: Bool = true {
+    didSet {
+      partialFormatter.withPrefix = withPrefix
+    }
+  }
+
+  @objc dynamic
+  public var currentRegion: String {
+    get {
+      return partialFormatter.currentRegion
+    }
+  }
+
+  //MARK: Lifecycle
+  public init(phoneNumberKit pnk: PhoneNumberKit = PhoneNumberKit(), defaultRegion: String = PhoneNumberKit.defaultRegionCode(), withPrefix: Bool = true) {
+    phoneNumberKit = pnk
+    self.partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: defaultRegion, withPrefix: withPrefix)
+    super.init()
+  }
+
+  public required init?(coder aDecoder: NSCoder) {
+    phoneNumberKit = PhoneNumberKit()
+    self.partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: defaultRegion, withPrefix: withPrefix)
+    super.init(coder: aDecoder)
+  }
+}
+
+// MARK: -
+// MARK: NSFormatter implementation
+extension PhoneNumberFormatter {
+
+  override open func string(for obj: Any?) -> String? {
+    if let pn = obj as? PhoneNumber {
+      return phoneNumberKit.format(pn, toType: withPrefix ? .international : .national)
+    }
+    if let str = obj as? String {
+      return partialFormatter.formatPartial(str)
+    }
+    return nil
+  }
+
+  override open func getObjectValue(_ obj: AutoreleasingUnsafeMutablePointer<AnyObject?>?, for string: String, errorDescription error: AutoreleasingUnsafeMutablePointer<NSString?>?) -> Bool {
+    if generatesPhoneNumber {
+      do {
+        obj?.pointee = try phoneNumberKit.parse(string) as AnyObject?
+        return true
+      } catch (let e) {
+        error?.pointee = e.localizedDescription as NSString
+        return false
+      }
+    } else {
+      obj?.pointee = string as NSString
+      return true
+    }
+  }
+
+  // MARK: Phone number formatting
+
+  /**
+   *  To keep the cursor position, we find the character immediately after the cursor and count the number of times it repeats in the remaining string as this will remain constant in every kind of editing.
+   */
+  private struct CursorPosition {
+    let numberAfterCursor: unichar
+    let repetitionCountFromEnd: Int
+  }
+
+  private func extractCursorPosition(from text: NSString, selection selectedTextRange: NSRange) -> CursorPosition? {
+    var repetitionCountFromEnd = 0
+
+    // The selection range is based on NSString representation
+    var cursorEnd = selectedTextRange.location + selectedTextRange.length
+
+    guard cursorEnd < text.length else {
+      // Cursor at end of string
+      return nil
+    }
+
+    // Get the character after the cursor
+    var char : unichar
+    repeat {
+      char = text.character(at: cursorEnd) // should work even if char is start of compound sequence
+      cursorEnd += 1
+      // We considere only digit as other caracters may be inserted by the formatter (especially spaces)
+    } while (!char.isDigit() && cursorEnd < text.length)
+
+    guard cursorEnd < text.length else {
+      // Cursor at end of string
+      return nil
+    }
+
+    // Look for the next valid number after the cursor, when found return a CursorPosition struct
+    for i in cursorEnd ..< text.length  {
+      if text.character(at: i) == char {
+        repetitionCountFromEnd += 1
+      }
+    }
+    return CursorPosition(numberAfterCursor: char, repetitionCountFromEnd: repetitionCountFromEnd)
+  }
+
+  private enum Action {
+    case insert
+    case replace
+    case delete
+  }
+
+  private func action(for origString : NSString, range: NSRange, proposedString: NSString, proposedRange: NSRange) -> Action {
+    // If origin range length > 0, this is a delete or replace action
+    if (range.length == 0) {
+      return .insert
+    }
+
+    // If proposed length = orig length - orig range length -> this is delete action
+    if (origString.length - range.length == proposedString.length) {
+      return .delete
+    }
+    // If proposed length > orig length - orig range length -> this is replace action
+    return .replace
+  }
+
+  override open func isPartialStringValid(_ partialStringPtr: AutoreleasingUnsafeMutablePointer<NSString>,
+                                          proposedSelectedRange proposedSelRangePtr: NSRangePointer?,
+                                          originalString origString: String,
+                                          originalSelectedRange origSelRange: NSRange,
+                                          errorDescription error: AutoreleasingUnsafeMutablePointer<NSString?>?) -> Bool {
+
+    guard let proposedSelRangePtr = proposedSelRangePtr else {
+      // I guess this is an annotation issue. I can't see a valid case where the pointer can be null
+      return true
+    }
+
+    // We want to allow space deletion or insertion
+    let orig = origString as NSString
+    let action = self.action(for: orig, range: origSelRange, proposedString: partialStringPtr.pointee, proposedRange: proposedSelRangePtr.pointee)
+    if action == .delete && orig.isWhiteSpace(in: origSelRange) {
+      // Deleting white space
+      return true
+    }
+
+    // Also allow to add white space ?
+    if action == .insert || action == .replace {
+      // Determine the inserted text range. This is the range starting at orig selection index and with length = ∆length
+      let length = partialStringPtr.pointee.length - orig.length + origSelRange.length
+      if partialStringPtr.pointee.isWhiteSpace(in: NSRange(location: origSelRange.location, length: length)) {
+        return true
+      }
+    }
+
+    let text = partialStringPtr.pointee as String
+    let formattedNationalNumber = partialFormatter.formatPartial(text)
+    guard formattedNationalNumber != text else {
+      // No change, no need to update the text
+      return true
+    }
+
+    // Fix selection
+
+    // The selection range is based on NSString representation
+    let formattedTextNSString = formattedNationalNumber as NSString
+    if let cursor = extractCursorPosition(from: partialStringPtr.pointee, selection: proposedSelRangePtr.pointee) {
+      var remaining = cursor.repetitionCountFromEnd
+      for i in stride(from: (formattedTextNSString.length - 1), through: 0, by: -1) {
+        if formattedTextNSString.character(at: i) == cursor.numberAfterCursor {
+          if remaining > 0 {
+            remaining -= 1
+          } else {
+            // We are done
+            proposedSelRangePtr.pointee = NSRange(location: i, length: 0)
+            break
+          }
+        }
+      }
+    } else {
+      // assume the pointer is at end of string
+      proposedSelRangePtr.pointee = NSRange(location: formattedTextNSString.length, length: 0)
+    }
+
+    partialStringPtr.pointee = formattedNationalNumber as NSString
+    return false
+  }
+
+}
+
+private extension NSString {
+  func isWhiteSpace(in range: NSRange) -> Bool {
+    return rangeOfCharacter(from: CharacterSet.whitespacesAndNewlines.inverted, options: [.literal], range: range).location == NSNotFound
+  }
+}
+
+private extension unichar {
+  func isDigit() -> Bool {
+    return self >= 0x30 && self <= 0x39 // '0' < '9'
+  }
+}


### PR DESCRIPTION
The main benefit of that class over the custom TextField is that is works on macOS and can be applied to any textfield or textfield subclass.

The drawback is that it does not manage the keyboard type on iOS.
