### PR TITLE
Link CoreTelephony only on supported platforms.

### DIFF
--- a/PhoneNumberKit.podspec
+++ b/PhoneNumberKit.podspec
@@ -30,7 +30,8 @@ Pod::Spec.new do |s|
 
   s.requires_arc = true
 
-  s.frameworks = 'CoreTelephony'
+  s.ios.frameworks = 'CoreTelephony'
+  s.osx.frameworks = 'CoreTelephony'
 
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.10'


### PR DESCRIPTION
This PR updates the podspec to only link `CoreTelephony` on supported platforms. I was getting builds failures on watchOS otherwise.