### PR TITLE
multiple parse optionally returns not parsed phone numbers

### DIFF
--- a/PhoneNumberKit/Constants.swift
+++ b/PhoneNumberKit/Constants.swift
@@ -89,6 +89,7 @@ public enum PhoneNumberType {
     case voip
     case uan
     case unknown
+    case notParsed
 }
 
 // MARK: Constants

--- a/PhoneNumberKit/ParseManager.swift
+++ b/PhoneNumberKit/ParseManager.swift
@@ -105,7 +105,7 @@ final class ParseManager {
     - parameter ignoreType:   Avoids number type checking for faster performance.
     - Returns: An array of valid PhoneNumber objects.
     */
-    func parseMultiple(_ numberStrings: [String], withRegion region: String, ignoreType: Bool, testCallback: (()->())? = nil) -> [PhoneNumber] {
+    func parseMultiple(_ numberStrings: [String], withRegion region: String, ignoreType: Bool, shouldReturnFailedEmptyNumbers: Bool = false, testCallback: (()->())? = nil) -> [PhoneNumber] {
         var multiParseArray = [PhoneNumber]()
         let group = DispatchGroup()
         let queue = DispatchQueue(label: "com.phonenumberkit.multipleparse", qos: .default)
@@ -116,8 +116,14 @@ final class ParseManager {
                 do {
                     if let phoneNumebr = try self?.parse(numberString, withRegion: region, ignoreType: ignoreType) {
                         multiParseArray.append(phoneNumebr)
+                    }else if shouldReturnFailedEmptyNumbers{
+                        multiParseArray.append(PhoneNumber.notPhoneNumber())
                     }
-                } catch {}
+                } catch {
+                    if shouldReturnFailedEmptyNumbers{
+                        multiParseArray.append(PhoneNumber.notPhoneNumber())
+                    }
+                }
                 group.leave()
             })
             if index == numberStrings.count/2 {

--- a/PhoneNumberKit/PhoneNumber.swift
+++ b/PhoneNumberKit/PhoneNumber.swift
@@ -46,6 +46,17 @@ extension PhoneNumber : Hashable {
 
 }
 
+extension PhoneNumber{
+    
+    public static func notPhoneNumber() -> PhoneNumber{
+        return PhoneNumber(numberString: "", countryCode: 0, leadingZero: false, nationalNumber: 0, numberExtension: nil, type: .notParsed)
+    }
+    
+    public func notParsed() -> Bool{
+        return type == .notParsed
+    }
+}
+
 /// In past versions of PhoneNumebrKit you were able to initialize a PhoneNumber object to parse a String. Please use a PhoneNumberKit object's methods.
 public extension PhoneNumber {
     /**

--- a/PhoneNumberKit/PhoneNumberKit.swift
+++ b/PhoneNumberKit/PhoneNumberKit.swift
@@ -44,8 +44,8 @@ public final class PhoneNumberKit: NSObject {
     /// - parameter ignoreType:   Avoids number type checking for faster performance.
     ///
     /// - returns: array of PhoneNumber objects.
-    public func parse(_ numberStrings: [String], withRegion region: String = PhoneNumberKit.defaultRegionCode(), ignoreType: Bool = false) -> [PhoneNumber] {
-        return parseManager.parseMultiple(numberStrings, withRegion: region, ignoreType: ignoreType)
+    public func parse(_ numberStrings: [String], withRegion region: String = PhoneNumberKit.defaultRegionCode(), ignoreType: Bool = false, shouldReturnFailedEmptyNumbers: Bool = false) -> [PhoneNumber] {
+        return parseManager.parseMultiple(numberStrings, withRegion: region, ignoreType: ignoreType, shouldReturnFailedEmptyNumbers: shouldReturnFailedEmptyNumbers)
     }
     
     // MARK: Formatting


### PR DESCRIPTION
I need it when i have some  CustomContact (some object with phone string) array and i want to filter this array to normalized contacts only. So i parse phone string array A to phone number array B that contain not parsed (empty phone numbers)  and A size matches to B size.