### PR TITLE
Support `maxDigits` property in PhoneNumberTextField

### DIFF
--- a/PhoneNumberKit/PartialFormatter.swift
+++ b/PhoneNumberKit/PartialFormatter.swift
@@ -52,7 +52,7 @@ public final class PartialFormatter {
     var currentMetadata: MetadataTerritory?
     var prefixBeforeNationalNumber =  String()
     var shouldAddSpaceAfterNationalPrefix = false
-    
+    var maxDigits: Int?
     var withPrefix = true
     
     //MARK: Status
@@ -88,6 +88,14 @@ public final class PartialFormatter {
             nationalNumber = extractCountryCallingCode(nationalNumber)
         }
         nationalNumber = extractNationalPrefix(nationalNumber)
+        
+        if let maxDigits = maxDigits {
+            let extra = nationalNumber.characters.count - maxDigits
+            
+            if extra > 0 {
+                nationalNumber = String(nationalNumber.characters.dropLast(extra))
+            }
+        }
         
         if let formats = availableFormats(nationalNumber) {
             if let formattedNumber = applyFormat(nationalNumber, formats: formats) {

--- a/PhoneNumberKit/UI/TextField.swift
+++ b/PhoneNumberKit/UI/TextField.swift
@@ -55,6 +55,11 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
     }
     public var isPartialFormatterEnabled = true
     
+    public var maxDigits: Int? {
+        didSet {
+            partialFormatter.maxDigits = maxDigits
+        }
+    }
     
     let partialFormatter: PartialFormatter
     


### PR DESCRIPTION
This does not use `possibleLengths` from the metadata, but that is a logical next step.