### PR TITLE
National number property in partial formatter and text field

### DIFF
--- a/PhoneNumberKit/UI/TextField.swift
+++ b/PhoneNumberKit/UI/TextField.swift
@@ -87,6 +87,14 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
             return partialFormatter.currentRegion
         }
     }
+    
+    public var nationalNumber: String {
+        get {
+            let rawNumber = self.text ?? String()
+            return partialFormatter.nationalNumber(from: rawNumber)
+        }
+    }
+    
     public var isValidNumber: Bool {
         get {
             let rawNumber = self.text ?? String()


### PR DESCRIPTION
Allows you to easily extract national number from a text field. Includes refactoring the partial formatter to expose the internal national number code.