### PR TITLE
Fix carthage build

### DIFF
--- a/PhoneNumberKit.xcodeproj/project.pbxproj
+++ b/PhoneNumberKit.xcodeproj/project.pbxproj
@@ -600,7 +600,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -652,7 +652,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";


### PR DESCRIPTION
While building carthage project with dependency to github "marmelroy/PhoneNumberKit" there was error:

`/Users/admin/Desktop/tmk-ios/DoctorRyadom/Carthage/Checkouts/PhoneNumberKit/PhoneNumberKit/PhoneNumberParser.swift:286:45: error: 'range(at:)' has been renamed to 'rangeAt(_:)'
                let firstRange = firstMatch.range(at: numOfGroups)
                                            ^~~~~ ~~~~
                                            rangeAt 
Foundation.NSTextCheckingResult:28:15: note: 'range(at:)' was introduced in Swift 4
    open func range(at idx: Int) -> NSRange
              ^

** BUILD FAILED **`


Problem - in project settings swift version was 3, while syntax is from swift 4