### PR TITLE
Fixed deprecation warnings new in Xcode 9.1 beta (9B37) caused by usage of string.characters

### DIFF
--- a/PhoneNumberKit.xcodeproj/project.pbxproj
+++ b/PhoneNumberKit.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 48;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -389,7 +389,7 @@
 				};
 			};
 			buildConfigurationList = 3424185E1BB6E5A000EE70E7 /* Build configuration list for PBXProject "PhoneNumberKit" */;
-			compatibilityVersion = "Xcode 3.2";
+			compatibilityVersion = "Xcode 8.0";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (

--- a/PhoneNumberKit/PartialFormatter.swift
+++ b/PhoneNumberKit/PartialFormatter.swift
@@ -84,16 +84,16 @@ public final class PartialFormatter {
         // Determine if number is valid by trying to instantiate a PhoneNumber object with it
         let iddFreeNumber = extractIDD(rawNumber)
         var nationalNumber = parser.normalizePhoneNumber(iddFreeNumber)
-        if prefixBeforeNationalNumber.characters.count > 0 {
+        if prefixBeforeNationalNumber.count > 0 {
             nationalNumber = extractCountryCallingCode(nationalNumber)
         }
         nationalNumber = extractNationalPrefix(nationalNumber)
         
         if let maxDigits = maxDigits {
-            let extra = nationalNumber.characters.count - maxDigits
+            let extra = nationalNumber.count - maxDigits
             
             if extra > 0 {
-                nationalNumber = String(nationalNumber.characters.dropLast(extra))
+                nationalNumber = String(nationalNumber.dropLast(extra))
             }
         }
         
@@ -111,16 +111,16 @@ public final class PartialFormatter {
             }
         }
         var finalNumber = String()
-        if prefixBeforeNationalNumber.characters.count > 0 {
+        if prefixBeforeNationalNumber.count > 0 {
             finalNumber.append(prefixBeforeNationalNumber)
         }
-        if shouldAddSpaceAfterNationalPrefix && prefixBeforeNationalNumber.characters.count > 0 && prefixBeforeNationalNumber.characters.last != PhoneNumberConstants.separatorBeforeNationalNumber.characters.first  {
+        if shouldAddSpaceAfterNationalPrefix && prefixBeforeNationalNumber.count > 0 && prefixBeforeNationalNumber.last != PhoneNumberConstants.separatorBeforeNationalNumber.first  {
             finalNumber.append(PhoneNumberConstants.separatorBeforeNationalNumber)
         }
-        if nationalNumber.characters.count > 0 {
+        if nationalNumber.count > 0 {
             finalNumber.append(nationalNumber)
         }
-        if finalNumber.characters.last == PhoneNumberConstants.separatorBeforeNationalNumber.characters.first {
+        if finalNumber.last == PhoneNumberConstants.separatorBeforeNationalNumber.first {
             finalNumber = String(finalNumber[..<finalNumber.index(before: finalNumber.endIndex)])
         }
         
@@ -155,10 +155,10 @@ public final class PartialFormatter {
     }
     
     internal func isNanpaNumberWithNationalPrefix(_ rawNumber: String) -> Bool {
-        guard currentMetadata?.countryCode == 1 && rawNumber.characters.count > 1 else { return false }
+        guard currentMetadata?.countryCode == 1 && rawNumber.count > 1 else { return false }
         
-        let firstCharacter: String = String(describing: rawNumber.characters.first)
-        let secondCharacter: String = String(describing: rawNumber.characters[rawNumber.characters.index(rawNumber.characters.startIndex, offsetBy: 1)])
+        let firstCharacter: String = String(describing: rawNumber.first)
+        let secondCharacter: String = String(describing: rawNumber[rawNumber.index(rawNumber.startIndex, offsetBy: 1)])
         return (firstCharacter == "1" && secondCharacter != "0" && secondCharacter != "1")
     }
     
@@ -168,7 +168,7 @@ public final class PartialFormatter {
         }
         do {
             let validRegex = try regexManager?.regexWithPattern(PhoneNumberPatterns.eligibleAsYouTypePattern)
-            if validRegex?.firstMatch(in: phoneFormat, options: [], range: NSMakeRange(0, phoneFormat.characters.count)) != nil {
+            if validRegex?.firstMatch(in: phoneFormat, options: [], range: NSMakeRange(0, phoneFormat.count)) != nil {
                 return true
             }
         }
@@ -185,8 +185,8 @@ public final class PartialFormatter {
                 let prefixPattern = String(format: PhoneNumberPatterns.iddPattern, arguments: [internationalPrefix])
                 let matches = try regexManager?.matchedStringByRegex(prefixPattern, string: rawNumber)
                 if let m = matches?.first {
-                    let startCallingCode = m.characters.count
-                    let index = rawNumber.characters.index(rawNumber.startIndex, offsetBy: startCallingCode)
+                    let startCallingCode = m.count
+                    let index = rawNumber.index(rawNumber.startIndex, offsetBy: startCallingCode)
                     processedNumber = String(rawNumber[index...])
                     prefixBeforeNationalNumber = String(rawNumber[..<index])
                 }
@@ -210,7 +210,7 @@ public final class PartialFormatter {
                     let nationalPrefixPattern = String(format: PhoneNumberPatterns.nationalPrefixParsingPattern, arguments: [nationalPrefix])
                     let matches = try regexManager?.matchedStringByRegex(nationalPrefixPattern, string: rawNumber)
                     if let m = matches?.first {
-                        startOfNationalNumber = m.characters.count
+                        startOfNationalNumber = m.count
                     }
                 }
             }
@@ -218,7 +218,7 @@ public final class PartialFormatter {
                 return processedNumber
             }
         }
-        let index = rawNumber.characters.index(rawNumber.startIndex, offsetBy: startOfNationalNumber)
+        let index = rawNumber.index(rawNumber.startIndex, offsetBy: startOfNationalNumber)
         processedNumber = String(rawNumber[index...])
         prefixBeforeNationalNumber.append(String(rawNumber[..<index]))
         return processedNumber
@@ -230,7 +230,7 @@ public final class PartialFormatter {
             return rawNumber
         }
         var numberWithoutCountryCallingCode = String()
-        if prefixBeforeNationalNumber.isEmpty == false && prefixBeforeNationalNumber.characters.first != "+" {
+        if prefixBeforeNationalNumber.isEmpty == false && prefixBeforeNationalNumber.first != "+" {
             prefixBeforeNationalNumber.append(PhoneNumberConstants.separatorBeforeNationalNumber)
         }
         if let potentialCountryCode = parser?.extractPotentialCountryCode(rawNumber, nationalNumber: &numberWithoutCountryCallingCode), potentialCountryCode != 0 {
@@ -288,7 +288,7 @@ public final class PartialFormatter {
                     if matches.count > 0 {
                         if let nationalPrefixFormattingRule = format.nationalPrefixFormattingRule {
                             let separatorRegex = try regexManager.regexWithPattern(PhoneNumberPatterns.prefixSeparatorPattern)
-                            let nationalPrefixMatches = separatorRegex.matches(in: nationalPrefixFormattingRule, options: [], range:  NSMakeRange(0, nationalPrefixFormattingRule.characters.count))
+                            let nationalPrefixMatches = separatorRegex.matches(in: nationalPrefixFormattingRule, options: [], range:  NSMakeRange(0, nationalPrefixFormattingRule.count))
                             if nationalPrefixMatches.count > 0 {
                                 shouldAddSpaceAfterNationalPrefix = true
                             }
@@ -324,7 +324,7 @@ public final class PartialFormatter {
             if let tempTemplate = getFormattingTemplate(numberPattern, numberFormat: numberFormat, rawNumber: rawNumber) {
                 if let nationalPrefixFormattingRule = format.nationalPrefixFormattingRule {
                     let separatorRegex = try regexManager.regexWithPattern(PhoneNumberPatterns.prefixSeparatorPattern)
-                    let nationalPrefixMatch = separatorRegex.firstMatch(in: nationalPrefixFormattingRule, options: [], range:  NSMakeRange(0, nationalPrefixFormattingRule.characters.count))
+                    let nationalPrefixMatch = separatorRegex.firstMatch(in: nationalPrefixFormattingRule, options: [], range:  NSMakeRange(0, nationalPrefixFormattingRule.count))
                     if nationalPrefixMatch != nil {
                         shouldAddSpaceAfterNationalPrefix = true
                     }
@@ -341,7 +341,7 @@ public final class PartialFormatter {
         do {
             let matches =  try regexManager.matchedStringByRegex(numberPattern, string: PhoneNumberConstants.longPhoneNumber)
             if let match = matches.first {
-                if match.characters.count < rawNumber.characters.count {
+                if match.count < rawNumber.count {
                     return nil
                 }
                 var template = regexManager.replaceStringByRegex(numberPattern, string: match, template: numberFormat)
@@ -358,22 +358,22 @@ public final class PartialFormatter {
     func applyFormattingTemplate(_ template: String, rawNumber: String) -> String {
         var rebuiltString = String()
         var rebuiltIndex = 0
-        for character in template.characters {
-            if character == PhoneNumberConstants.digitPlaceholder.characters.first {
-                if rebuiltIndex < rawNumber.characters.count {
-                    let nationalCharacterIndex = rawNumber.characters.index(rawNumber.startIndex, offsetBy: rebuiltIndex)
+        for character in template {
+            if character == PhoneNumberConstants.digitPlaceholder.first {
+                if rebuiltIndex < rawNumber.count {
+                    let nationalCharacterIndex = rawNumber.index(rawNumber.startIndex, offsetBy: rebuiltIndex)
                     rebuiltString.append(rawNumber[nationalCharacterIndex])
                     rebuiltIndex += 1
                 }
             }
             else {
-                if rebuiltIndex < rawNumber.characters.count {
+                if rebuiltIndex < rawNumber.count {
                     rebuiltString.append(character)
                 }
             }
         }
-        if rebuiltIndex < rawNumber.characters.count {
-            let nationalCharacterIndex = rawNumber.characters.index(rawNumber.startIndex, offsetBy: rebuiltIndex)
+        if rebuiltIndex < rawNumber.count {
+            let nationalCharacterIndex = rawNumber.index(rawNumber.startIndex, offsetBy: rebuiltIndex)
             let remainingNationalNumber: String = String(rawNumber[nationalCharacterIndex...])
             rebuiltString.append(remainingNationalNumber)
         }

--- a/PhoneNumberKit/PhoneNumberParser.swift
+++ b/PhoneNumberKit/PhoneNumberParser.swift
@@ -48,7 +48,7 @@ final class PhoneNumberParser {
         }
         let countryCodeSource = stripInternationalPrefixAndNormalize(&fullNumber, possibleIddPrefix: possibleCountryIddPrefix)
         if countryCodeSource != .defaultCountry {
-            if fullNumber.characters.count <= PhoneNumberConstants.minLengthForNSN {
+            if fullNumber.count <= PhoneNumberConstants.minLengthForNSN {
                 throw PhoneNumberError.tooShort
             }
             if let potentialCountryCode = extractPotentialCountryCode(fullNumber, nationalNumber: &nationalNumber), potentialCountryCode != 0 {
@@ -62,7 +62,7 @@ final class PhoneNumberParser {
             let defaultCountryCode = String(metadata.countryCode)
             if fullNumber.hasPrefix(defaultCountryCode) {
                 let nsFullNumber = fullNumber as NSString
-                var potentialNationalNumber = nsFullNumber.substring(from: defaultCountryCode.characters.count)
+                var potentialNationalNumber = nsFullNumber.substring(from: defaultCountryCode.count)
                 guard let validNumberPattern = metadata.generalDesc?.nationalNumberPattern, let possibleNumberPattern = metadata.generalDesc?.possibleNumberPattern else {
                     return 0
                 }
@@ -194,7 +194,7 @@ final class PhoneNumberParser {
                     return false
                 }
                 let matchedString = number.substring(with: matched.range)
-                let matchEnd = matchedString.characters.count
+                let matchEnd = matchedString.count
                 let remainString = (number as NSString).substring(from: matchEnd)
                 let capturingDigitPatterns = try NSRegularExpression(pattern: PhoneNumberPatterns.capturingDigitPattern, options: NSRegularExpression.Options.caseInsensitive)
                 let matchedGroups = capturingDigitPatterns.matches(in: remainString as String)
@@ -284,13 +284,13 @@ final class PhoneNumberParser {
                 let numOfGroups = firstMatch.numberOfRanges - 1
                 var transformedNumber: String = String()
                 let firstRange = firstMatch.range(at: numOfGroups)
-                let firstMatchStringWithGroup = (firstRange.location != NSNotFound && firstRange.location < number.characters.count) ? number.substring(with: firstRange):  String()
+                let firstMatchStringWithGroup = (firstRange.location != NSNotFound && firstRange.location < number.count) ? number.substring(with: firstRange):  String()
                 let firstMatchStringWithGroupHasValue = regex.hasValue(firstMatchStringWithGroup)
                 if let transformRule = metadata.nationalPrefixTransformRule , firstMatchStringWithGroupHasValue == true {
                     transformedNumber = regex.replaceFirstStringByRegex(prefixPattern, string: number, templateString: transformRule)
                 }
                 else {
-                    let index = number.index(number.startIndex, offsetBy: firstMatchString.characters.count)
+                    let index = number.index(number.startIndex, offsetBy: firstMatchString.count)
                     transformedNumber = String(number[index...])
                 }
                 if (regex.hasValue(nationalNumberRule) && regex.matchesEntirely(nationalNumberRule, string: number) && regex.matchesEntirely(nationalNumberRule, string: transformedNumber) == false){

--- a/PhoneNumberKit/RegexManager.swift
+++ b/PhoneNumberKit/RegexManager.swift
@@ -189,8 +189,8 @@ final class RegexManager {
     
     func stringByReplacingOccurrences(_ string: String, map: [String:String]) -> String {
         var targetString = String()
-        for i in 0 ..< string.characters.count {
-            let oneChar = string[string.characters.index(string.startIndex, offsetBy: i)]
+        for i in 0 ..< string.count {
+            let oneChar = string[string.index(string.startIndex, offsetBy: i)]
             let keyString = String(oneChar).uppercased()
             if let mappedValue = map[keyString] {
                 targetString.append(mappedValue)
@@ -203,7 +203,7 @@ final class RegexManager {
     
     func hasValue(_ value: String?) -> Bool {
         if let valueString = value {
-            if valueString.trimmingCharacters(in: spaceCharacterSet).characters.count == 0 {
+            if valueString.trimmingCharacters(in: spaceCharacterSet).count == 0 {
                 return false
             }
             return true

--- a/PhoneNumberKit/UI/TextField.swift
+++ b/PhoneNumberKit/UI/TextField.swift
@@ -210,7 +210,7 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
         let changedRange = textAsNSString.substring(with: range) as NSString
         let modifiedTextField = textAsNSString.replacingCharacters(in: range, with: string)
         
-        let filteredCharacters = modifiedTextField.characters.filter {
+        let filteredCharacters = modifiedTextField.filter {
             return  String($0).rangeOfCharacter(from: (textField as! PhoneNumberTextField).nonNumericSet as CharacterSet) == nil
         }
         let rawNumberString = String(filteredCharacters)

--- a/PhoneNumberKitTests/PhoneNumberKitParsingTests.swift
+++ b/PhoneNumberKitTests/PhoneNumberKitParsingTests.swift
@@ -226,7 +226,7 @@ class PhoneNumberKitParsingTests: XCTestCase {
     }
     
     func testAllExampleNumbers() {
-        let metaDataArray = phoneNumberKit.metadataManager.territories.filter{$0.codeID.characters.count == 2}
+        let metaDataArray = phoneNumberKit.metadataManager.territories.filter{$0.codeID.count == 2}
         for metadata in metaDataArray {
             let codeID = metadata.codeID
             let metadataWithTypes: [(MetadataPhoneNumberDesc?, PhoneNumberType?)] = [


### PR DESCRIPTION
Also, updated project format to 'Xcode 8-compatible'. Was 'Xcode 3.2-compatible'.  Pretty sure we'll never see Swift 4 back-ported to Xcode 3.2 ;)