### PR TITLE
Fix thread safety of PhoneNumberKit.parse()

### DIFF
--- a/PhoneNumberKit/RegexManager.swift
+++ b/PhoneNumberKit/RegexManager.swift
@@ -14,30 +14,37 @@ final class RegexManager {
 
     var regularExpresionPool = [String: NSRegularExpression]()
 
+    private let regularExpressionPoolQueue = DispatchQueue(label: "com.phonenumberkit.regexpool", attributes: .concurrent)
+
     var spaceCharacterSet: CharacterSet = {
         let characterSet = NSMutableCharacterSet(charactersIn: "\u{00a0}")
         characterSet.formUnion(with: CharacterSet.whitespacesAndNewlines)
         return characterSet as CharacterSet
     }()
 
-    deinit {
-        regularExpresionPool.removeAll()
-    }
-
     // MARK: Regular expression
 
     func regexWithPattern(_ pattern: String) throws -> NSRegularExpression {
-        if let regex = regularExpresionPool[pattern] {
-            return regex
-        } else {
-            do {
-                let regularExpression: NSRegularExpression
-                regularExpression =  try NSRegularExpression(pattern: pattern, options:NSRegularExpression.Options.caseInsensitive)
-                regularExpresionPool[pattern] = regularExpression
-                return regularExpression
-            } catch {
-                throw PhoneNumberError.generalError
+        var cached: NSRegularExpression?
+
+        regularExpressionPoolQueue.sync {
+            cached = self.regularExpresionPool[pattern]
+        }
+
+        if let cached = cached {
+            return cached
+        }
+
+        do {
+            let regex = try NSRegularExpression(pattern: pattern, options: .caseInsensitive)
+
+            regularExpressionPoolQueue.async(flags: .barrier) {
+                self.regularExpresionPool[pattern] = regex
             }
+
+            return regex
+        } catch {
+            throw PhoneNumberError.generalError
         }
     }
 


### PR DESCRIPTION
This makes `PhoneNumberKit.parse()` thread safe. Fixes #193.