### PR TITLE
[PhoneNumberTextField] Do not format text when the formatter is disabled

### DIFF
--- a/PhoneNumberKit/UI/TextField.swift
+++ b/PhoneNumberKit/UI/TextField.swift
@@ -17,7 +17,7 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
     /// Override setText so number will be automatically formatted when setting text by code
     override open var text: String? {
         set {
-            if newValue != nil {
+            if isPartialFormatterEnabled && newValue != nil {
                 let formattedNumber = partialFormatter.formatPartial(newValue! as String)
                 super.text = formattedNumber
             }


### PR DESCRIPTION
Hi!

I've noticed that `PhoneNumberTextField` formats the text you set vía the `text` property even if the flag `isPartialFormatterEnabled` is false. So I've fixed it 😄 