### PR TITLE
Added Codable to PhoneNumber

### DIFF
--- a/PhoneNumberKit/Constants.swift
+++ b/PhoneNumberKit/Constants.swift
@@ -76,7 +76,7 @@ public enum PhoneNumberFormat {
  - uan: UAN numbers
  - unknown: Unknown number type
  */
-public enum PhoneNumberType {
+public enum PhoneNumberType: String, Codable {
     case fixedLine
     case mobile
     case fixedOrMobile

--- a/PhoneNumberKit/PhoneNumber.swift
+++ b/PhoneNumberKit/PhoneNumber.swift
@@ -18,7 +18,7 @@ Parsed phone number object
 - numberExtension: Extension if available. String. Optional
 - type: Computed phone number type on access. Returns from an enumeration - PNPhoneNumberType.
 */
-public struct PhoneNumber {
+public struct PhoneNumber: Codable {
     public let numberString: String
     public let countryCode: UInt64
     public let leadingZero: Bool


### PR DESCRIPTION
Made PhoneNumber codable so that it can be saved and transferred in JSON, XML ,or other transfer formats.