### PR TITLE
Prevent national number prefix from being returned.

### DIFF
--- a/PhoneNumberKit/PartialFormatter.swift
+++ b/PhoneNumberKit/PartialFormatter.swift
@@ -52,6 +52,7 @@ public final class PartialFormatter {
     var currentMetadata: MetadataTerritory?
     var prefixBeforeNationalNumber =  String()
     var shouldAddSpaceAfterNationalPrefix = false
+    var showNationalNumberPrefix = true
     var maxDigits: Int?
     var withPrefix = true
     
@@ -118,12 +119,16 @@ public final class PartialFormatter {
             }
         }
         var finalNumber = String()
-        if prefixBeforeNationalNumber.count > 0 {
-            finalNumber.append(prefixBeforeNationalNumber)
+        
+        if showNationalNumberPrefix {
+            if prefixBeforeNationalNumber.count > 0 {
+                finalNumber.append(prefixBeforeNationalNumber)
+            }
+            if shouldAddSpaceAfterNationalPrefix && prefixBeforeNationalNumber.count > 0 && prefixBeforeNationalNumber.last != PhoneNumberConstants.separatorBeforeNationalNumber.first  {
+                finalNumber.append(PhoneNumberConstants.separatorBeforeNationalNumber)
+            }
         }
-        if shouldAddSpaceAfterNationalPrefix && prefixBeforeNationalNumber.count > 0 && prefixBeforeNationalNumber.last != PhoneNumberConstants.separatorBeforeNationalNumber.first  {
-            finalNumber.append(PhoneNumberConstants.separatorBeforeNationalNumber)
-        }
+        
         if nationalNumber.count > 0 {
             finalNumber.append(nationalNumber)
         }

--- a/PhoneNumberKit/UI/TextField.swift
+++ b/PhoneNumberKit/UI/TextField.swift
@@ -42,6 +42,12 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
         }
     }
     
+    public var showNationalNumberPrefix = true {
+        didSet {
+            partialFormatter.showNationalNumberPrefix = showNationalNumberPrefix
+        }
+    }
+    
     public var withPrefix: Bool = true {
         didSet {
             partialFormatter.withPrefix = withPrefix
@@ -119,6 +125,7 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
     override public init(frame:CGRect)
     {
         self.partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: defaultRegion, withPrefix: withPrefix)
+        
         super.init(frame:frame)
         self.setup()
     }


### PR DESCRIPTION
In our presentation of phone number acquisition, we have a separate pick list for country code. Need to disable this functionality in both PartialFormatter and PhoneNumberTextField to prevent the country code from being duplicated.