### PR TITLE
Expose possibleLengths from json, allow querying by country and phone number type

### DIFF
--- a/PhoneNumberKit/Constants.swift
+++ b/PhoneNumberKit/Constants.swift
@@ -93,6 +93,11 @@ public enum PhoneNumberType: String, Codable {
     case notParsed
 }
 
+public enum PossibleLengthType: String, Codable {
+  case national
+  case localOnly
+}
+
 // MARK: Constants
 
 struct PhoneNumberConstants {

--- a/PhoneNumberKit/MetadataTypes.swift
+++ b/PhoneNumberKit/MetadataTypes.swift
@@ -63,11 +63,18 @@ public struct MetadataTerritory: Decodable {
  - Parameter exampleNumber: An example phone number for the given type. Optional.
  - Parameter nationalNumberPattern:  National number regex pattern. Optional.
  - Parameter possibleNumberPattern:  Possible number regex pattern. Optional.
+ - Parameter possibleLengths: Possible phone number lengths. Optional.
  */
 public struct MetadataPhoneNumberDesc: Decodable {
     public let exampleNumber: String?
     public let nationalNumberPattern: String?
     public let possibleNumberPattern: String?
+    public let possibleLengths: MetadataPossibleLengths?
+}
+
+public struct MetadataPossibleLengths: Decodable {
+    let national: String?
+    let localOnly: String?
 }
 
 /**


### PR DESCRIPTION
We are using this to assign a value to `PhoneNumberTextField.maxDigits`, based on the user's currently selected country code / region code. I'm more than happy to make adjustments and add tests for this pull request if the general functionality is of interest. Just let me know.

