### PR TITLE
Fix UITextFieldTextDidChange notification in PhoneNumberTextField

### DIFF
--- a/PhoneNumberKit/UI/TextField.swift
+++ b/PhoneNumberKit/UI/TextField.swift
@@ -23,6 +23,7 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
             } else {
                 super.text = newValue
             }
+            NotificationCenter.default.post(name: Notification.Name.UITextFieldTextDidChange, object: self)
         }
         get {
             return super.text

--- a/PhoneNumberKit/UI/TextField.swift
+++ b/PhoneNumberKit/UI/TextField.swift
@@ -23,7 +23,7 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
             } else {
                 super.text = newValue
             }
-            NotificationCenter.default.post(name: Notification.Name.UITextFieldTextDidChange, object: self)
+            NotificationCenter.default.post(name: UITextField.textDidChangeNotification, object: self)
         }
         get {
             return super.text


### PR DESCRIPTION
Sometimes it is more convenient to track changes in text fields using NotificationCenter:

`
NotificationCenter.default.addObserver(
        self,
        selector: #selector(onTextFieldValueChanged),
        name: Notification.Name.UITextFieldTextDidChange,
        object: textField
)
`

But UITextFieldTextDidChange notification is broken in PhoneNumberTextField because of overriding `text` property.

This pull-request fixes the sending of notification.

Reference to UITextFieldTextDidChange notification:
https://developer.apple.com/documentation/uikit/uitextfieldtextdidchangenotification?language=objc