### PR TITLE
Add possibility of textfield defaultregion override

### DIFF
--- a/PhoneNumberKit/UI/TextField.swift
+++ b/PhoneNumberKit/UI/TextField.swift
@@ -41,6 +41,15 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
         get {
             return self._defaultRegion
         }
+        @available(*,
+            deprecated,
+            message: """
+                The setter of defaultRegion is deprecated,
+                please override defaultRegion in a subclass instead.
+            """
+        )
+        set {
+        }
     }
 
     public var withPrefix: Bool = true {
@@ -60,10 +69,10 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
             partialFormatter.maxDigits = maxDigits
         }
     }
-
-    private var _partialFormatter: PartialFormatter?
     
-    var partialFormatter: PartialFormatter {
+    private var _partialFormatter: PartialFormatter?
+
+    private var partialFormatter: PartialFormatter {
         return self._partialFormatter!
     }
 

--- a/PhoneNumberKit/UI/TextField.swift
+++ b/PhoneNumberKit/UI/TextField.swift
@@ -70,11 +70,11 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
         }
     }
     
-    private var _partialFormatter: PartialFormatter?
-
-    public var partialFormatter: PartialFormatter {
-        return self._partialFormatter!
-    }
+    public private(set) lazy var partialFormatter: PartialFormatter = PartialFormatter(
+        phoneNumberKit: phoneNumberKit,
+        defaultRegion: defaultRegion,
+        withPrefix: withPrefix
+    )
 
     let nonNumericSet: NSCharacterSet = {
         var mutableSet = NSMutableCharacterSet.decimalDigit().inverted
@@ -131,7 +131,6 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
      */
     override public init(frame: CGRect) {
         super.init(frame:frame)
-        self._partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: defaultRegion, withPrefix: withPrefix)
         self.setup()
     }
 
@@ -144,7 +143,6 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
      */
     required public init(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)!
-        self._partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: defaultRegion, withPrefix: withPrefix)
         self.setup()
     }
 

--- a/PhoneNumberKit/UI/TextField.swift
+++ b/PhoneNumberKit/UI/TextField.swift
@@ -34,10 +34,12 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
         super.text = newValue
     }
 
+    private lazy var _defaultRegion: String = PhoneNumberKit.defaultRegionCode()
+
     /// Override region to set a custom region. Automatically uses the default region code.
-    open var defaultRegion = PhoneNumberKit.defaultRegionCode() {
-        didSet {
-            partialFormatter.defaultRegion = defaultRegion
+    open var defaultRegion: String {
+        get {
+            return self._defaultRegion
         }
     }
 
@@ -59,7 +61,11 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
         }
     }
 
-    let partialFormatter: PartialFormatter
+    private var _partialFormatter: PartialFormatter?
+    
+    var partialFormatter: PartialFormatter {
+        return self._partialFormatter!
+    }
 
     let nonNumericSet: NSCharacterSet = {
         var mutableSet = NSMutableCharacterSet.decimalDigit().inverted
@@ -115,8 +121,8 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
      - returns: UITextfield
      */
     override public init(frame: CGRect) {
-        self.partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: defaultRegion, withPrefix: withPrefix)
         super.init(frame:frame)
+        self._partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: defaultRegion, withPrefix: withPrefix)
         self.setup()
     }
 
@@ -128,8 +134,8 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
      - returns: UITextfield
      */
     required public init(coder aDecoder: NSCoder) {
-        self.partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: defaultRegion, withPrefix: withPrefix)
         super.init(coder: aDecoder)!
+        self._partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: defaultRegion, withPrefix: withPrefix)
         self.setup()
     }
 

--- a/PhoneNumberKit/UI/TextField.swift
+++ b/PhoneNumberKit/UI/TextField.swift
@@ -72,7 +72,7 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
     
     private var _partialFormatter: PartialFormatter?
 
-    private var partialFormatter: PartialFormatter {
+    public var partialFormatter: PartialFormatter {
         return self._partialFormatter!
     }
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,17 @@ phoneNumberKit.format(phoneNumber, toType: .national) // (02) 3661 8300
 
 To use the AsYouTypeFormatter, just replace your UITextField with a PhoneNumberTextField (if you are using Interface Builder make sure the module field is set to PhoneNumberKit).
 
-PhoneNumberTextField automatically formats phone numbers and gives the user full editing capabilities. If you want to customize you can use the PartialFormatter directly. The default region code is automatically computed but can be overridden if needed.  
+PhoneNumberTextField automatically formats phone numbers and gives the user full editing capabilities. If you want to customize you can use the PartialFormatter directly. The default region code is automatically computed but can be overridden if needed (see the example given below).
+```swift
+class MyGBTextField: PhoneNumberTextField {
+    override var defaultRegion: String {
+        get {
+            return "GB"
+        }
+        set {} // exists for backward compatibility
+    }
+}
+```
 
 ![AsYouTypeFormatter](http://i.giphy.com/3o6gbgrudyCM8Ak6yc.gif)
 


### PR DESCRIPTION
Since [stored properties cannot be overridden](https://stackoverflow.com/questions/26691935/overriding-a-stored-property-in-swift) resolves #289