### PR TITLE
Use PhoneNumberTextField using SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .library(name: "PhoneNumberKit", targets: ["PhoneNumberKit"])
     ],
     targets: [
-        .target(name: "PhoneNumberKit", path: "PhoneNumberKit", exclude: ["UI"]),
+        .target(name: "PhoneNumberKit", path: "PhoneNumberKit", exclude: []),
         .testTarget(name: "PhoneNumberKitTests", dependencies: ["PhoneNumberKit"], path: "PhoneNumberKitTests")
     ]
 )


### PR DESCRIPTION
This change allows to use PhoneNumberTextField in projects using Xcode 11 and which installed this using Swift Package Manager.