### PR TITLE
Expose the metadata to the API consumer

### DIFF
--- a/PhoneNumberKit/MetadataParsing.swift
+++ b/PhoneNumberKit/MetadataParsing.swift
@@ -10,7 +10,7 @@ import Foundation
 
 // MARK: - MetadataTerritory
 
-extension MetadataTerritory {
+public extension MetadataTerritory {
 
     enum CodingKeys: String, CodingKey {
         case codeID = "id"
@@ -78,7 +78,7 @@ extension MetadataTerritory {
 
 // MARK: - MetadataPhoneNumberFormat
 
-extension MetadataPhoneNumberFormat {
+public extension MetadataPhoneNumberFormat {
     enum CodingKeys: String, CodingKey {
         case pattern
         case format

--- a/PhoneNumberKit/MetadataTypes.swift
+++ b/PhoneNumberKit/MetadataTypes.swift
@@ -32,30 +32,30 @@ import Foundation
  - Parameter uan: MetadataPhoneNumberDesc for uan numbers
  - Parameter leadingDigits: Optional leading digits for the territory
  */
-struct MetadataTerritory: Decodable {
-    let codeID: String
-    let countryCode: UInt64
-    let internationalPrefix: String?
-    let mainCountryForCode: Bool
-    let nationalPrefix: String?
-    let nationalPrefixFormattingRule: String?
-    let nationalPrefixForParsing: String?
-    let nationalPrefixTransformRule: String?
-    let preferredExtnPrefix: String?
-    let emergency: MetadataPhoneNumberDesc?
-    let fixedLine: MetadataPhoneNumberDesc?
-    let generalDesc: MetadataPhoneNumberDesc?
-    let mobile: MetadataPhoneNumberDesc?
-    let pager: MetadataPhoneNumberDesc?
-    let personalNumber: MetadataPhoneNumberDesc?
-    let premiumRate: MetadataPhoneNumberDesc?
-    let sharedCost: MetadataPhoneNumberDesc?
-    let tollFree: MetadataPhoneNumberDesc?
-    let voicemail: MetadataPhoneNumberDesc?
-    let voip: MetadataPhoneNumberDesc?
-    let uan: MetadataPhoneNumberDesc?
-    let numberFormats: [MetadataPhoneNumberFormat]
-    let leadingDigits: String?
+public struct MetadataTerritory: Decodable {
+    public let codeID: String
+    public let countryCode: UInt64
+    public let internationalPrefix: String?
+    public let mainCountryForCode: Bool
+    public let nationalPrefix: String?
+    public let nationalPrefixFormattingRule: String?
+    public let nationalPrefixForParsing: String?
+    public let nationalPrefixTransformRule: String?
+    public let preferredExtnPrefix: String?
+    public let emergency: MetadataPhoneNumberDesc?
+    public let fixedLine: MetadataPhoneNumberDesc?
+    public let generalDesc: MetadataPhoneNumberDesc?
+    public let mobile: MetadataPhoneNumberDesc?
+    public let pager: MetadataPhoneNumberDesc?
+    public let personalNumber: MetadataPhoneNumberDesc?
+    public let premiumRate: MetadataPhoneNumberDesc?
+    public let sharedCost: MetadataPhoneNumberDesc?
+    public let tollFree: MetadataPhoneNumberDesc?
+    public let voicemail: MetadataPhoneNumberDesc?
+    public let voip: MetadataPhoneNumberDesc?
+    public let uan: MetadataPhoneNumberDesc?
+    public let numberFormats: [MetadataPhoneNumberFormat]
+    public let leadingDigits: String?
 }
 
 /**
@@ -64,10 +64,10 @@ MetadataPhoneNumberDesc object
 - Parameter nationalNumberPattern:  National number regex pattern. Optional.
 - Parameter possibleNumberPattern:  Possible number regex pattern. Optional.
 */
-struct MetadataPhoneNumberDesc: Decodable {
-    let exampleNumber: String?
-    let nationalNumberPattern: String?
-    let possibleNumberPattern: String?
+public struct MetadataPhoneNumberDesc: Decodable {
+    public let exampleNumber: String?
+    public let nationalNumberPattern: String?
+    public let possibleNumberPattern: String?
 }
 
 /**
@@ -81,14 +81,14 @@ struct MetadataPhoneNumberDesc: Decodable {
  - Parameter nationalPrefixOptionalWhenFormatting: National prefix optional bool. Optional.
  - Parameter domesticCarrierCodeFormattingRule: Domestic carrier code formatting rule. Optional.
  */
-struct MetadataPhoneNumberFormat: Decodable {
-    let pattern: String?
-    let format: String?
-    let intlFormat: String?
-    let leadingDigitsPatterns: [String]?
-    var nationalPrefixFormattingRule: String?
-    let nationalPrefixOptionalWhenFormatting: Bool?
-    let domesticCarrierCodeFormattingRule: String?
+public struct MetadataPhoneNumberFormat: Decodable {
+    public let pattern: String?
+    public let format: String?
+    public let intlFormat: String?
+    public let leadingDigitsPatterns: [String]?
+    public var nationalPrefixFormattingRule: String?
+    public let nationalPrefixOptionalWhenFormatting: Bool?
+    public let domesticCarrierCodeFormattingRule: String?
 }
 
 /// Internal object for metadata parsing

--- a/PhoneNumberKit/PhoneNumberKit.swift
+++ b/PhoneNumberKit/PhoneNumberKit.swift
@@ -148,6 +148,22 @@ public final class PhoneNumberKit: NSObject {
         return parseManager.getRegionCode(of: phoneNumber.nationalNumber, countryCode: phoneNumber.countryCode, leadingZero: phoneNumber.leadingZero)
     }
 
+    /// Get the MetadataTerritory objects for an ISO 639 compliant region code.
+    ///
+    /// - parameter country: ISO 639 compliant region code (e.g "GB" for the UK).
+    ///
+    /// - returns: A MetadataTerritory object, or nil if no metadata was found for the country code
+    public func metadata(for country: String) -> MetadataTerritory? {
+        return metadataManager.filterTerritories(byCountry: country)
+    }
+
+    /// Get an array of MetadataTerritory objects corresponding to a given country code.
+    ///
+    /// - parameter countryCode: international country code (e.g 44 for the UK)
+    public func metadata(forCode countryCode: UInt64) -> [MetadataTerritory]? {
+        return metadataManager.filterTerritories(byCode: countryCode)
+    }
+
     // MARK: Class functions
 
     /// Get a user's default region code

--- a/README.md
+++ b/README.md
@@ -99,6 +99,13 @@ phoneNumberKit.countries(withCode: 33)
 phoneNumberKit.countryCode(for: "FR")
 ```
 
+## Need more customization?
+
+You can access the metadata powering PhoneNumberKit yourself, this enables you to program any behaviours as they may be implemented in PhoneNumberKit itself. It does mean you are exposed to the less polished interface of the underlying file format. If you program something you find useful please push it upstream!
+```swift
+phoneNumberKit.metadata(for: "AU")?.mobile?.exampleNumber // 412345678
+```
+
 ### Setting up with Carthage
 
 [Carthage](https://github.com/Carthage/Carthage) is a decentralized dependency manager that automates the process of adding frameworks to your Cocoa application.


### PR DESCRIPTION
This enables consumers of this SDK to extend the behaviours provided by accessing the backing metadata in the same way the SDK itself does. This way consumers of the SDK can implement new functionality on top of it, hopefully in the form of wrappers or extensions that hopefully find their way back into PhoneNumberKit itself. 

## Example uses

### #178 & #159
> Add function to get example number for country code

 Short of having the SDK provide a API to access example numbers through, consumers can implement what they wish on top of the metadata already loaded into their apps. 

### #156
> Get country from a given phone number

This would also enable users to access an array of Territories that share a common country code (USA, Canada, ...) and search the metadata for leading digits.

Any application with functionality highly specific to phone numbers would also benefit from not needing to reimplement the parser included in PhoneNumberKit