### PR TITLE
Allow PhoneNumberTextField to accept a PhoneNumberKit instance on init

### DIFF
--- a/PhoneNumberKit.xcodeproj/project.pbxproj
+++ b/PhoneNumberKit.xcodeproj/project.pbxproj
@@ -8,13 +8,13 @@
 
 /* Begin PBXBuildFile section */
 		11C2EF391D62BC3200052D44 /* NSRegularExpression+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C2EF381D62BC3200052D44 /* NSRegularExpression+Swift.swift */; };
-		1B80904E2300B4DC006AE849 /* MetadataParsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3417BD6A2210AC4900477EE7 /* MetadataParsing.swift */; };
-		1B80904F2300B4DC006AE849 /* MetadataParsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3417BD6A2210AC4900477EE7 /* MetadataParsing.swift */; };
-		1B8090502300B4DD006AE849 /* MetadataParsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3417BD6A2210AC4900477EE7 /* MetadataParsing.swift */; };
 		1B0651171E2AD698006AE849 /* PhoneNumberFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B0651161E2AD698006AE849 /* PhoneNumberFormatter.swift */; };
 		1B1A4DD723007580006AE849 /* PhoneNumberFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B0651161E2AD698006AE849 /* PhoneNumberFormatter.swift */; };
 		1B1A4DD82300759E006AE849 /* PhoneNumberFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B0651161E2AD698006AE849 /* PhoneNumberFormatter.swift */; };
 		1B1A4DD9230075A6006AE849 /* PhoneNumberFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B0651161E2AD698006AE849 /* PhoneNumberFormatter.swift */; };
+		1B80904E2300B4DC006AE849 /* MetadataParsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3417BD6A2210AC4900477EE7 /* MetadataParsing.swift */; };
+		1B80904F2300B4DC006AE849 /* MetadataParsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3417BD6A2210AC4900477EE7 /* MetadataParsing.swift */; };
+		1B8090502300B4DD006AE849 /* MetadataParsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3417BD6A2210AC4900477EE7 /* MetadataParsing.swift */; };
 		3417BD6B2210AC4900477EE7 /* MetadataParsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3417BD6A2210AC4900477EE7 /* MetadataParsing.swift */; };
 		3420CF5E1BE8959F00FAE34F /* Formatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3420CF5D1BE8959F00FAE34F /* Formatter.swift */; };
 		3422D9BA1BE6A2D500867D02 /* ParseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3422D9B91BE6A2D500867D02 /* ParseManager.swift */; };
@@ -76,6 +76,7 @@
 		C6DF6CDF1D1B18D800259F4B /* PhoneNumberParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 342418811BB70F5200EE70E7 /* PhoneNumberParser.swift */; };
 		C6DF6CE01D1B18D800259F4B /* RegexManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34566C991BC112C500715E6B /* RegexManager.swift */; };
 		C6DF6CE11D1B18DD00259F4B /* PhoneNumberMetadata.json in Resources */ = {isa = PBXBuildFile; fileRef = 3435CC951BBFF66F003F953B /* PhoneNumberMetadata.json */; };
+		C9D81F822348025700B75AB7 /* TextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D81F812348025700B75AB7 /* TextFieldTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -117,6 +118,7 @@
 		C6DF6C911D1B120400259F4B /* PhoneNumberKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PhoneNumberKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C6DF6CA71D1B145300259F4B /* PhoneNumberKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PhoneNumberKit.h; sourceTree = "<group>"; };
 		C6DF6CCC1D1B18B000259F4B /* PhoneNumberKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PhoneNumberKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C9D81F812348025700B75AB7 /* TextFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -231,6 +233,7 @@
 				346EF14D1C69C688008C7306 /* PartialFormatterTests.swift */,
 				34776AA71BE2BF1100400790 /* PhoneNumberKitParsingTests.swift */,
 				342418751BB6E5A000EE70E7 /* Info.plist */,
+				C9D81F812348025700B75AB7 /* TextFieldTests.swift */,
 			);
 			path = PhoneNumberKitTests;
 			sourceTree = "<group>";
@@ -496,6 +499,7 @@
 				34776AA81BE2BF1100400790 /* PhoneNumberKitParsingTests.swift in Sources */,
 				342418741BB6E5A000EE70E7 /* PhoneNumberKitTests.swift in Sources */,
 				346EF14E1C69C688008C7306 /* PartialFormatterTests.swift in Sources */,
+				C9D81F822348025700B75AB7 /* TextFieldTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PhoneNumberKit/UI/TextField.swift
+++ b/PhoneNumberKit/UI/TextField.swift
@@ -11,8 +11,7 @@ import UIKit
 
 /// Custom text field that formats phone numbers
 open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
-
-    public let phoneNumberKit = PhoneNumberKit()
+    public let phoneNumberKit: PhoneNumberKit!
 
     /// Override setText so number will be automatically formatted when setting text by code
     override open var text: String? {
@@ -123,6 +122,33 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
     // MARK: Lifecycle
 
     /**
+     Init with a phone number kit instance. Because a PhoneNumberKit initialization is expensive,
+     you can pass a pre-initialized instance to avoid incurring perf penalties.
+
+     - parameter phoneNumberKit: A PhoneNumberKit instance to be used by the text field.
+
+     - returns: UITextfield
+     */
+    public convenience init(withPhoneNumberKit phoneNumberKit: PhoneNumberKit) {
+        self.init(frame: .zero, phoneNumberKit: phoneNumberKit)
+    }
+
+    /**
+     Init with frame and phone number kit instance.
+
+     - parameter frame: UITextfield frame
+     - parameter phoneNumberKit: A PhoneNumberKit instance to be used by the text field.
+
+     - returns: UITextfield
+     */
+    public init(frame: CGRect, phoneNumberKit: PhoneNumberKit) {
+        self.phoneNumberKit = phoneNumberKit
+        super.init(frame: frame)
+        self.setup()
+    }
+
+
+    /**
      Init with frame
      
      - parameter frame: UITextfield F
@@ -130,6 +156,7 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
      - returns: UITextfield
      */
     override public init(frame: CGRect) {
+        phoneNumberKit = PhoneNumberKit()
         super.init(frame:frame)
         self.setup()
     }
@@ -142,6 +169,7 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
      - returns: UITextfield
      */
     required public init(coder aDecoder: NSCoder) {
+        phoneNumberKit = PhoneNumberKit()
         super.init(coder: aDecoder)!
         self.setup()
     }

--- a/PhoneNumberKitTests/TextFieldTests.swift
+++ b/PhoneNumberKitTests/TextFieldTests.swift
@@ -1,0 +1,29 @@
+//
+//  TextFieldTests.swift
+//  PhoneNumberKitTests
+//
+//  Created by Travis Kaufman on 10/4/19.
+//  Copyright © 2019 Roy Marmelstein. All rights reserved.
+//
+
+import XCTest
+import UIKit
+@testable import PhoneNumberKit
+
+class TextFieldTests: XCTestCase {
+    func testWorksWithPhoneNumberKitInstance() {
+        let pnk = PhoneNumberKit()
+        let tf = PhoneNumberTextField(withPhoneNumberKit: pnk)
+        tf.text = "4125551212"
+        XCTAssertEqual(tf.text, "(412) 555-1212")
+    }
+
+    func testWorksWithFrameAndPhoneNumberKitInstance() {
+        let pnk = PhoneNumberKit()
+        let frame = CGRect(x: 10.0, y: 20.0, width: 400.0, height: 250.0)
+        let tf = PhoneNumberTextField(frame: frame, phoneNumberKit: pnk)
+        XCTAssertEqual(tf.frame, frame)
+        tf.text = "4125551212"
+        XCTAssertEqual(tf.text, "(412) 555-1212")
+    }
+}


### PR DESCRIPTION
Because of the JSON metadata parsing done by PhoneNumberKit, it's
expensive to initialize a PhoneNumberTextField instance. This PR adds a
new initializer that accepts a `PhoneNumberKit` instance to avoid having
to re-load / parse JSON.

Fixes #196 