### PR TITLE
Add Country Code Picker UI using flag icon

### DIFF
--- a/PhoneNumberKit.xcodeproj/project.pbxproj
+++ b/PhoneNumberKit.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		34CA34522380307300788D7D /* PhoneNumberMetadata.json in Resources */ = {isa = PBXBuildFile; fileRef = A863BC9923801ABC00088460 /* PhoneNumberMetadata.json */; };
 		34FD5D2B1D55F7AE00F328F9 /* PhoneNumberKit.h in Headers */ = {isa = PBXBuildFile; fileRef = C6DF6CA71D1B145300259F4B /* PhoneNumberKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		34FD5D2C1D55F7AE00F328F9 /* PhoneNumberKit.h in Headers */ = {isa = PBXBuildFile; fileRef = C6DF6CA71D1B145300259F4B /* PhoneNumberKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5D14267D238F5842002DD197 /* CountryCodePickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D14267C238F5842002DD197 /* CountryCodePickerViewController.swift */; };
 		A863BC9B23801ABC00088460 /* PhoneNumberMetadata.json in Resources */ = {isa = PBXBuildFile; fileRef = A863BC9923801ABC00088460 /* PhoneNumberMetadata.json */; };
 		A863BC9C23801ABC00088460 /* PhoneNumberMetadata.json in Resources */ = {isa = PBXBuildFile; fileRef = A863BC9923801ABC00088460 /* PhoneNumberMetadata.json */; };
 		A863BC9D23801ABC00088460 /* PhoneNumberMetadata.json in Resources */ = {isa = PBXBuildFile; fileRef = A863BC9923801ABC00088460 /* PhoneNumberMetadata.json */; };
@@ -113,6 +114,7 @@
 		34776AA71BE2BF1100400790 /* PhoneNumberKitParsingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhoneNumberKitParsingTests.swift; sourceTree = "<group>"; };
 		34AA66011BDD160B00467912 /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		34AA66031BDD448B00467912 /* CoreTelephony.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreTelephony.framework; path = System/Library/Frameworks/CoreTelephony.framework; sourceTree = SDKROOT; };
+		5D14267C238F5842002DD197 /* CountryCodePickerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CountryCodePickerViewController.swift; path = UI/CountryCodePickerViewController.swift; sourceTree = "<group>"; };
 		A863BC9923801ABC00088460 /* PhoneNumberMetadata.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = PhoneNumberMetadata.json; path = Resources/PhoneNumberMetadata.json; sourceTree = "<group>"; };
 		C6DF6C4B1D1B09CF00259F4B /* PhoneNumberKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PhoneNumberKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C6DF6C911D1B120400259F4B /* PhoneNumberKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PhoneNumberKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -218,6 +220,7 @@
 				3420CF5D1BE8959F00FAE34F /* Formatter.swift */,
 				343B850A1C62A25600918E46 /* PartialFormatter.swift */,
 				343B850B1C62A25600918E46 /* TextField.swift */,
+				5D14267C238F5842002DD197 /* CountryCodePickerViewController.swift */,
 				342418811BB70F5200EE70E7 /* PhoneNumberParser.swift */,
 				1B0651161E2AD698006AE849 /* PhoneNumberFormatter.swift */,
 				11C2EF381D62BC3200052D44 /* NSRegularExpression+Swift.swift */,
@@ -482,6 +485,7 @@
 				346922671BC01DCC0023482F /* MetadataManager.swift in Sources */,
 				3420CF5E1BE8959F00FAE34F /* Formatter.swift in Sources */,
 				343B850D1C62A25600918E46 /* TextField.swift in Sources */,
+				5D14267D238F5842002DD197 /* CountryCodePickerViewController.swift in Sources */,
 				3417BD6B2210AC4900477EE7 /* MetadataParsing.swift in Sources */,
 				346922691BC023A60023482F /* PhoneNumberKit.swift in Sources */,
 				343B850C1C62A25600918E46 /* PartialFormatter.swift in Sources */,

--- a/PhoneNumberKit/PhoneNumberKit.swift
+++ b/PhoneNumberKit/PhoneNumberKit.swift
@@ -157,22 +157,22 @@ public final class PhoneNumberKit: NSObject {
         let metadata = self.metadata(for: countryCode)
         let example: String?
         switch type {
-        case .fixedLine:      example = metadata?.fixedLine?.exampleNumber
-        case .mobile:         example = metadata?.mobile?.exampleNumber
-        case .fixedOrMobile:  example = metadata?.mobile?.exampleNumber
-        case .pager:          example = metadata?.pager?.exampleNumber
+        case .fixedLine: example = metadata?.fixedLine?.exampleNumber
+        case .mobile: example = metadata?.mobile?.exampleNumber
+        case .fixedOrMobile: example = metadata?.mobile?.exampleNumber
+        case .pager: example = metadata?.pager?.exampleNumber
         case .personalNumber: example = metadata?.personalNumber?.exampleNumber
-        case .premiumRate:    example = metadata?.premiumRate?.exampleNumber
-        case .sharedCost:     example = metadata?.sharedCost?.exampleNumber
-        case .tollFree:       example = metadata?.tollFree?.exampleNumber
-        case .voicemail:      example = metadata?.voicemail?.exampleNumber
-        case .voip:           example = metadata?.voip?.exampleNumber
-        case .uan:            example = metadata?.uan?.exampleNumber
-        case .unknown:        return nil
-        case .notParsed:      return nil
+        case .premiumRate: example = metadata?.premiumRate?.exampleNumber
+        case .sharedCost: example = metadata?.sharedCost?.exampleNumber
+        case .tollFree: example = metadata?.tollFree?.exampleNumber
+        case .voicemail: example = metadata?.voicemail?.exampleNumber
+        case .voip: example = metadata?.voip?.exampleNumber
+        case .uan: example = metadata?.uan?.exampleNumber
+        case .unknown: return nil
+        case .notParsed: return nil
         }
         do {
-            return try example.flatMap({ try parse($0, withRegion: countryCode, ignoreType: false) })
+            return try example.flatMap { try parse($0, withRegion: countryCode, ignoreType: false) }
         } catch {
             print("[PhoneNumberKit] Failed to parse example number for \(countryCode) region")
             return nil
@@ -189,10 +189,10 @@ public final class PhoneNumberKit: NSObject {
     /// - returns: A formatted example phone number
     public func getFormattedExampleNumber(
         forCountry countryCode: String, ofType type: PhoneNumberType = .mobile,
-        withFormat format: PhoneNumberFormat = .international, withPrefix prefix: Bool = true) -> String?
-    {
-        return getExampleNumber(forCountry: countryCode, ofType: type)
-            .flatMap({ self.format($0, toType: format, withPrefix: prefix) })
+        withFormat format: PhoneNumberFormat = .international, withPrefix prefix: Bool = true
+    ) -> String? {
+        return self.getExampleNumber(forCountry: countryCode, ofType: type)
+            .flatMap { self.format($0, toType: format, withPrefix: prefix) }
     }
 
     /// Get the MetadataTerritory objects for an ISO 639 compliant region code.

--- a/PhoneNumberKit/PhoneNumberKit.swift
+++ b/PhoneNumberKit/PhoneNumberKit.swift
@@ -157,54 +157,6 @@ public final class PhoneNumberKit: NSObject {
         let metadata = self.metadata(for: countryCode)
         let example: String?
         switch type {
-        case .fixedLine: example = metadata?.fixedLine?.exampleNumber
-        case .mobile: example = metadata?.mobile?.exampleNumber
-        case .fixedOrMobile: example = metadata?.mobile?.exampleNumber
-        case .pager: example = metadata?.pager?.exampleNumber
-        case .personalNumber: example = metadata?.personalNumber?.exampleNumber
-        case .premiumRate: example = metadata?.premiumRate?.exampleNumber
-        case .sharedCost: example = metadata?.sharedCost?.exampleNumber
-        case .tollFree: example = metadata?.tollFree?.exampleNumber
-        case .voicemail: example = metadata?.voicemail?.exampleNumber
-        case .voip: example = metadata?.voip?.exampleNumber
-        case .uan: example = metadata?.uan?.exampleNumber
-        case .unknown: return nil
-        case .notParsed: return nil
-        }
-        do {
-            return try example.flatMap { try parse($0, withRegion: countryCode, ignoreType: false) }
-        } catch {
-            print("[PhoneNumberKit] Failed to parse example number for \(countryCode) region")
-            return nil
-        }
-    }
-
-    /// Get a formatted example phone number for an ISO 639 compliant region code.
-    ///
-    /// - parameter countryCode: ISO 639 compliant region code.
-    /// - parameter type: `PhoneNumberType` desired. default: `.mobile`
-    /// - parameter format: `PhoneNumberFormat` to use for formatting. default: `.international`
-    /// - parameter prefix: Whether or not to include the prefix.
-    ///
-    /// - returns: A formatted example phone number
-    public func getFormattedExampleNumber(
-        forCountry countryCode: String, ofType type: PhoneNumberType = .mobile,
-        withFormat format: PhoneNumberFormat = .international, withPrefix prefix: Bool = true
-    ) -> String? {
-        return self.getExampleNumber(forCountry: countryCode, ofType: type)
-            .flatMap { self.format($0, toType: format, withPrefix: prefix) }
-    }
-
-    /// Get an example phone number for an ISO 639 compliant region code.
-    ///
-    /// - parameter countryCode: ISO 639 compliant region code.
-    /// - parameter type: The `PhoneNumberType` desired. default: `.mobile`
-    ///
-    /// - returns: An example phone number
-    public func getExampleNumber(forCountry countryCode: String, ofType type: PhoneNumberType = .mobile) -> PhoneNumber? {
-        let metadata = self.metadata(for: countryCode)
-        let example: String?
-        switch type {
         case .fixedLine:      example = metadata?.fixedLine?.exampleNumber
         case .mobile:         example = metadata?.mobile?.exampleNumber
         case .fixedOrMobile:  example = metadata?.mobile?.exampleNumber

--- a/PhoneNumberKit/PhoneNumberKit.swift
+++ b/PhoneNumberKit/PhoneNumberKit.swift
@@ -195,6 +195,54 @@ public final class PhoneNumberKit: NSObject {
             .flatMap { self.format($0, toType: format, withPrefix: prefix) }
     }
 
+    /// Get an example phone number for an ISO 639 compliant region code.
+    ///
+    /// - parameter countryCode: ISO 639 compliant region code.
+    /// - parameter type: The `PhoneNumberType` desired. default: `.mobile`
+    ///
+    /// - returns: An example phone number
+    public func getExampleNumber(forCountry countryCode: String, ofType type: PhoneNumberType = .mobile) -> PhoneNumber? {
+        let metadata = self.metadata(for: countryCode)
+        let example: String?
+        switch type {
+        case .fixedLine:      example = metadata?.fixedLine?.exampleNumber
+        case .mobile:         example = metadata?.mobile?.exampleNumber
+        case .fixedOrMobile:  example = metadata?.mobile?.exampleNumber
+        case .pager:          example = metadata?.pager?.exampleNumber
+        case .personalNumber: example = metadata?.personalNumber?.exampleNumber
+        case .premiumRate:    example = metadata?.premiumRate?.exampleNumber
+        case .sharedCost:     example = metadata?.sharedCost?.exampleNumber
+        case .tollFree:       example = metadata?.tollFree?.exampleNumber
+        case .voicemail:      example = metadata?.voicemail?.exampleNumber
+        case .voip:           example = metadata?.voip?.exampleNumber
+        case .uan:            example = metadata?.uan?.exampleNumber
+        case .unknown:        return nil
+        case .notParsed:      return nil
+        }
+        do {
+            return try example.flatMap({ try parse($0, withRegion: countryCode, ignoreType: false) })
+        } catch {
+            print("[PhoneNumberKit] Failed to parse example number for \(countryCode) region")
+            return nil
+        }
+    }
+
+    /// Get a formatted example phone number for an ISO 639 compliant region code.
+    ///
+    /// - parameter countryCode: ISO 639 compliant region code.
+    /// - parameter type: `PhoneNumberType` desired. default: `.mobile`
+    /// - parameter format: `PhoneNumberFormat` to use for formatting. default: `.international`
+    /// - parameter prefix: Whether or not to include the prefix.
+    ///
+    /// - returns: A formatted example phone number
+    public func getFormattedExampleNumber(
+        forCountry countryCode: String, ofType type: PhoneNumberType = .mobile,
+        withFormat format: PhoneNumberFormat = .international, withPrefix prefix: Bool = true) -> String?
+    {
+        return getExampleNumber(forCountry: countryCode, ofType: type)
+            .flatMap({ self.format($0, toType: format, withPrefix: prefix) })
+    }
+
     /// Get the MetadataTerritory objects for an ISO 639 compliant region code.
     ///
     /// - parameter country: ISO 639 compliant region code (e.g "GB" for the UK).

--- a/PhoneNumberKit/PhoneNumberKit.swift
+++ b/PhoneNumberKit/PhoneNumberKit.swift
@@ -247,3 +247,17 @@ public final class PhoneNumberKit: NSObject {
         return data
     }
 }
+
+#if canImport(UIKit)
+extension PhoneNumberKit {
+
+    /// Configuration for the CountryCodePicker presented from PhoneNumberTextField if `withDefaultPickerUI` is `true`
+    public enum CountryCodePicker {
+        /// Common Country Codes are shown below the Current section in the CountryCodePicker by default
+        public static var commonCountryCodes: [String] = []
+
+        /// When the Picker is shown from the textfield it is presented modally
+        public static var forceModalPresentation: Bool = false
+    }
+}
+#endif

--- a/PhoneNumberKit/UI/CountryCodePickerViewController.swift
+++ b/PhoneNumberKit/UI/CountryCodePickerViewController.swift
@@ -117,7 +117,9 @@ class CountryCodePickerViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        if section == 0, hasCurrent {
+        if isFiltering {
+            return nil
+        } else if section == 0, hasCurrent {
             return "Current"
         } else if section == 0, !hasCurrent && hasPopular {
             return "Popular"

--- a/PhoneNumberKit/UI/CountryCodePickerViewController.swift
+++ b/PhoneNumberKit/UI/CountryCodePickerViewController.swift
@@ -1,0 +1,225 @@
+
+import UIKit
+
+@available(iOS 11.0, *)
+protocol CountryCodePickerDelegate: class {
+    func countryCodePickerViewControllerDidPickCountry(_ country: CountryCodePickerViewController.Country)
+}
+
+@available(iOS 11.0, *)
+class CountryCodePickerViewController: UITableViewController {
+
+    lazy var searchController = UISearchController(searchResultsController: nil)
+
+    public let phoneNumberKit: PhoneNumberKit
+
+    var shouldRestoreNavigationBarToHidden = false
+
+    /// Popular Country Codes are shown below the Current section
+    public static var popularCountryCodes: [String] = []
+
+    var hasCurrent = true
+    var hasPopular = true
+
+    lazy var allCountries = phoneNumberKit
+        .allCountries()
+        .compactMap({ Country(for: $0, with: self.phoneNumberKit) })
+        .sorted(by: { $0.name.caseInsensitiveCompare($1.name) == .orderedAscending })
+
+    lazy var countries: [[Country]] = {
+        let countries = allCountries
+            .reduce([[Country]]()) { collection, country in
+                var collection = collection
+                guard var lastGroup = collection.last else { return [[country]] }
+                let lhs = lastGroup.first?.name.folding(options: .diacriticInsensitive, locale: nil)
+                let rhs = country.name.folding(options: .diacriticInsensitive, locale: nil)
+                if lhs?.first == rhs.first {
+                    lastGroup.append(country)
+                    collection[collection.count - 1] = lastGroup
+                } else {
+                    collection.append([country])
+                }
+                return collection
+            }
+
+        let popular = Self.popularCountryCodes.compactMap({ Country(for: $0, with: phoneNumberKit) })
+
+        var result: [[Country]] = []
+        // Note we should maybe use the user's current carrier's country code?
+        if hasCurrent, let current = Country(for: PhoneNumberKit.defaultRegionCode(), with: phoneNumberKit) {
+            result.append([current])
+        }
+        hasPopular = hasPopular && !popular.isEmpty
+        if hasPopular {
+            result.append(popular)
+        }
+        return result + countries
+    }()
+
+    var filteredCountries: [Country] = []
+
+    weak var delegate: CountryCodePickerDelegate?
+
+    init(phoneNumberKit: PhoneNumberKit) {
+        self.phoneNumberKit = phoneNumberKit
+        super.init(style: .grouped)
+
+        self.title = "Choose your country"
+
+        tableView.register(Cell.self, forCellReuseIdentifier: Cell.reuseIdentifier)
+        searchController.searchResultsUpdater = self
+        searchController.obscuresBackgroundDuringPresentation = false
+        searchController.searchBar.backgroundColor = .clear
+        navigationItem.searchController = searchController
+        definesPresentationContext = true
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        if let nav = navigationController {
+            shouldRestoreNavigationBarToHidden = nav.isNavigationBarHidden
+            nav.setNavigationBarHidden(false, animated: true)
+        }
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        navigationController?.setNavigationBarHidden(shouldRestoreNavigationBarToHidden, animated: true)
+    }
+
+    func country(for indexPath: IndexPath) -> Country {
+        isFiltering ? filteredCountries[indexPath.row] : countries[indexPath.section][indexPath.row]
+    }
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        isFiltering ? 1 : countries.count
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        isFiltering ? filteredCountries.count : countries[section].count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: Cell.reuseIdentifier, for: indexPath)
+        let country = self.country(for: indexPath)
+
+        cell.textLabel?.text = country.prefix + " " + country.flag
+        cell.detailTextLabel?.text = country.name
+
+        cell.textLabel?.font = .preferredFont(forTextStyle: .callout)
+        cell.detailTextLabel?.font = .preferredFont(forTextStyle: .body)
+
+        return cell
+    }
+
+    override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        if section == 0, hasCurrent {
+            return "Current"
+        } else if section == 0, !hasCurrent && hasPopular {
+            return "Popular"
+        } else if section == 1 && hasCurrent && hasPopular {
+            return "Popular"
+        }
+        return countries[section].first?.name.first.map(String.init)
+    }
+
+    override func sectionIndexTitles(for tableView: UITableView) -> [String]? {
+        guard !isFiltering else {
+            return nil
+        }
+        var titles: [String] = []
+        if hasCurrent {
+            titles.append("•") // NOTE: SFSymbols are not supported otherwise we would use 􀋑
+        }
+        if hasPopular {
+            titles.append("★") // This is a classic unicode star
+        }
+        return titles + countries.suffix(countries.count - titles.count).map { group in
+            group.first?.name.first
+                .map(String.init)?
+                .folding(options: .diacriticInsensitive, locale: nil) ?? ""
+        }
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let country = self.country(for: indexPath)
+        delegate?.countryCodePickerViewControllerDidPickCountry(country)
+        tableView.deselectRow(at: indexPath, animated: true)
+    }
+}
+
+@available(iOS 11.0, *)
+extension CountryCodePickerViewController: UISearchResultsUpdating {
+
+    var isFiltering: Bool {
+        searchController.isActive && !isSearchBarEmpty
+    }
+
+    var isSearchBarEmpty: Bool {
+        searchController.searchBar.text?.isEmpty ?? true
+    }
+
+    func updateSearchResults(for searchController: UISearchController) {
+        let searchText = searchController.searchBar.text ?? ""
+        filteredCountries = allCountries.filter { country in
+            country.name.lowercased().contains(searchText.lowercased()) ||
+                country.code.lowercased().contains(searchText.lowercased()) ||
+                country.prefix.lowercased().contains(searchText.lowercased())
+        }
+        tableView.reloadData()
+    }
+}
+
+
+// MARK: Types
+
+@available(iOS 11.0, *)
+extension CountryCodePickerViewController {
+
+    struct Country {
+        var code: String
+        var flag: String
+        var name: String
+        var prefix: String
+
+        init?(for countryCode: String, with phoneNumberKit: PhoneNumberKit) {
+            let flagBase = UnicodeScalar("🇦").value - UnicodeScalar("A").value
+            guard
+                let name = (Locale.current as NSLocale).localizedString(forCountryCode: countryCode),
+                let prefix = phoneNumberKit.countryCode(for: countryCode)?.description
+            else {
+                    return nil
+            }
+
+            self.code = countryCode
+            self.name = name
+            self.prefix = "+" + prefix
+            self.flag = ""
+            countryCode.uppercased().unicodeScalars.forEach {
+                if let scaler = UnicodeScalar(flagBase + $0.value) {
+                    flag.append(String(describing: scaler))
+                }
+            }
+            if flag.count != 1 { // Failed to initialize a flag ... use an empty string
+                return nil
+            }
+        }
+    }
+
+    class Cell: UITableViewCell {
+
+        static let reuseIdentifier = "Cell"
+
+        override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+            super.init(style: .value2, reuseIdentifier: Self.reuseIdentifier)
+        }
+
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+    }
+}

--- a/PhoneNumberKit/UI/CountryCodePickerViewController.swift
+++ b/PhoneNumberKit/UI/CountryCodePickerViewController.swift
@@ -1,4 +1,6 @@
 
+#if canImport(UIKit)
+
 import UIKit
 
 @available(iOS 11.0, *)
@@ -234,3 +236,5 @@ internal extension CountryCodePickerViewController {
         }
     }
 }
+
+#endif

--- a/PhoneNumberKit/UI/TextField.swift
+++ b/PhoneNumberKit/UI/TextField.swift
@@ -435,7 +435,7 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
 extension PhoneNumberTextField: CountryCodePickerDelegate {
 
     func countryCodePickerViewControllerDidPickCountry(_ country: CountryCodePickerViewController.Country) {
-        text = ""
+        text = isEditing ? "+" + country.prefix : ""
         _defaultRegion = country.code
         partialFormatter.defaultRegion = country.code
         updateFlag()

--- a/PhoneNumberKit/UI/TextField.swift
+++ b/PhoneNumberKit/UI/TextField.swift
@@ -88,12 +88,18 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
         }
     }
 
-    public var withDefaultPickerUI: Bool = false {
+    private var _withDefaultPickerUI: Bool = false {
         didSet {
             if #available(iOS 11.0, *), flagButton.actions(forTarget: self, forControlEvent: .touchUpInside) == nil {
                 flagButton.addTarget(self, action: #selector(didPressFlagButton), for: .touchUpInside)
             }
         }
+    }
+
+    @available(iOS 11.0, *)
+    public var withDefaultPickerUI: Bool {
+        get { _withDefaultPickerUI }
+        set { _withDefaultPickerUI = newValue }
     }
 
     public var isPartialFormatterEnabled = true
@@ -264,7 +270,7 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
         guard withDefaultPickerUI else { return }
         let vc = CountryCodePickerViewController(phoneNumberKit: phoneNumberKit)
         vc.delegate = self
-        if let nav = containingViewController?.navigationController {
+        if let nav = containingViewController?.navigationController, !PhoneNumberKit.CountryCodePicker.forceModalPresentation {
             nav.pushViewController(vc, animated: true)
         } else {
             let nav = UINavigationController(rootViewController: vc)

--- a/PhoneNumberKit/UI/TextField.swift
+++ b/PhoneNumberKit/UI/TextField.swift
@@ -91,7 +91,6 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
     public var withDefaultPickerUI: Bool = false {
         didSet {
             if #available(iOS 11.0, *), flagButton.actions(forTarget: self, forControlEvent: .touchUpInside) == nil {
-                print(#function)
                 flagButton.addTarget(self, action: #selector(didPressFlagButton), for: .touchUpInside)
             }
         }

--- a/examples/AsYouType/Sample/Base.lproj/Main.storyboard
+++ b/examples/AsYouType/Sample/Base.lproj/Main.storyboard
@@ -28,7 +28,7 @@
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalCentering" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Jz3-GQ-0AX">
-                                <rect key="frame" x="36" y="130" width="528" height="109"/>
+                                <rect key="frame" x="36" y="130" width="528" height="148"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vKY-YQ-0hZ">
                                         <rect key="frame" x="0.0" y="0.0" width="528" height="31"/>
@@ -81,10 +81,27 @@
                                             </switch>
                                         </subviews>
                                     </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Jpr-Yc-iVG">
+                                        <rect key="frame" x="0.0" y="117" width="528" height="31"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="withDefaultPickerUI" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ojl-wu-bPW">
+                                                <rect key="frame" x="0.0" y="0.0" width="479" height="31"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="nV1-lR-6LE">
+                                                <rect key="frame" x="479" y="0.0" width="51" height="31"/>
+                                                <connections>
+                                                    <action selector="withDefaultPickerUIDidChange:" destination="BYZ-38-t0r" eventType="valueChanged" id="EKx-XU-qn0"/>
+                                                </connections>
+                                            </switch>
+                                        </subviews>
+                                    </stackView>
                                 </subviews>
                             </stackView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Above are the options you have to configure the text field" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5TG-DO-EsG">
-                                <rect key="frame" x="20" y="271" width="560" height="20.5"/>
+                                <rect key="frame" x="20" y="310" width="560" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
@@ -112,6 +129,7 @@
                     <size key="freeformSize" width="600" height="600"/>
                     <connections>
                         <outlet property="textField" destination="RfZ-67-gtf" id="dgp-k7-Gek"/>
+                        <outlet property="withDefaultPickerUISwitch" destination="nV1-lR-6LE" id="l6H-lU-uxK"/>
                         <outlet property="withExamplePlaceholderSwitch" destination="J2G-b9-t87" id="0Zm-n4-rDz"/>
                         <outlet property="withFlagSwitch" destination="uoY-qU-AJO" id="4f8-6a-0wu"/>
                         <outlet property="withPrefixSwitch" destination="pXB-8Z-JGO" id="jKy-NW-9yP"/>

--- a/examples/AsYouType/Sample/ViewController.swift
+++ b/examples/AsYouType/Sample/ViewController.swift
@@ -12,10 +12,12 @@ import PhoneNumberKit
 import UIKit
 
 class ViewController: UIViewController, CNContactPickerDelegate {
+    
     @IBOutlet var textField: PhoneNumberTextField!
     @IBOutlet var withPrefixSwitch: UISwitch!
     @IBOutlet var withFlagSwitch: UISwitch!
     @IBOutlet var withExamplePlaceholderSwitch: UISwitch!
+    @IBOutlet var withDefaultPickerUISwitch: UISwitch!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -57,5 +59,9 @@ class ViewController: UIViewController, CNContactPickerDelegate {
         if !self.textField.withExamplePlaceholder {
             self.textField.placeholder = "Enter phone number"
         }
+    }
+
+    @IBAction func withDefaultPickerUIDidChange(_ sender: Any) {
+        self.textField.withDefaultPickerUI = self.withDefaultPickerUISwitch.isOn
     }
 }

--- a/examples/AsYouType/Sample/ViewController.swift
+++ b/examples/AsYouType/Sample/ViewController.swift
@@ -21,10 +21,16 @@ class ViewController: UIViewController, CNContactPickerDelegate {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        // Country picker is only available on >iOS 11.0
+        if #available(iOS 11.0, *) {
+            CountryCodePickerViewController.commonCountryCodes = ["US", "CA", "MX", "AU", "GB", "DE"]
+        }
         self.textField.becomeFirstResponder()
         self.withPrefixSwitch.isOn = self.textField.withPrefix
         self.withFlagSwitch.isOn = self.textField.withFlag
         self.withExamplePlaceholderSwitch.isOn = self.textField.withExamplePlaceholder
+        self.withDefaultPickerUI.isOn = self.textField.withDefaultPickerUI
     }
 
     @IBAction func didTapView(_ sender: Any) {

--- a/examples/AsYouType/Sample/ViewController.swift
+++ b/examples/AsYouType/Sample/ViewController.swift
@@ -12,7 +12,6 @@ import PhoneNumberKit
 import UIKit
 
 class ViewController: UIViewController, CNContactPickerDelegate {
-    
     @IBOutlet var textField: PhoneNumberTextField!
     @IBOutlet var withPrefixSwitch: UISwitch!
     @IBOutlet var withFlagSwitch: UISwitch!
@@ -30,26 +29,11 @@ class ViewController: UIViewController, CNContactPickerDelegate {
         self.withPrefixSwitch.isOn = self.textField.withPrefix
         self.withFlagSwitch.isOn = self.textField.withFlag
         self.withExamplePlaceholderSwitch.isOn = self.textField.withExamplePlaceholder
-        self.withDefaultPickerUI.isOn = self.textField.withDefaultPickerUI
+        self.withDefaultPickerUISwitch.isOn = self.textField.withDefaultPickerUI
     }
 
     @IBAction func didTapView(_ sender: Any) {
         self.textField.resignFirstResponder()
-    }
-
-    @IBAction func withPrefixDidChange(_ sender: Any) {
-        self.textField.withPrefix = self.withPrefixSwitch.isOn
-    }
-
-    @IBAction func withFlagDidChange(_ sender: Any) {
-        self.textField.withFlag = self.withFlagSwitch.isOn
-    }
-
-    @IBAction func withExamplePlaceholderDidChange(_ sender: Any) {
-        self.textField.withExamplePlaceholder = self.withExamplePlaceholderSwitch.isOn
-        if !self.textField.withExamplePlaceholder {
-            self.textField.placeholder = "Enter phone number"
-        }
     }
 
     @IBAction func withPrefixDidChange(_ sender: Any) {

--- a/examples/AsYouType/Sample/ViewController.swift
+++ b/examples/AsYouType/Sample/ViewController.swift
@@ -23,13 +23,15 @@ class ViewController: UIViewController, CNContactPickerDelegate {
 
         // Country picker is only available on >iOS 11.0
         if #available(iOS 11.0, *) {
-            CountryCodePickerViewController.commonCountryCodes = ["US", "CA", "MX", "AU", "GB", "DE"]
+            PhoneNumberKit.CountryCodePicker.commonCountryCodes = ["US", "CA", "MX", "AU", "GB", "DE"]
         }
         self.textField.becomeFirstResponder()
         self.withPrefixSwitch.isOn = self.textField.withPrefix
         self.withFlagSwitch.isOn = self.textField.withFlag
         self.withExamplePlaceholderSwitch.isOn = self.textField.withExamplePlaceholder
-        self.withDefaultPickerUISwitch.isOn = self.textField.withDefaultPickerUI
+        if #available(iOS 11.0, *) {
+            self.withDefaultPickerUISwitch.isOn = self.textField.withDefaultPickerUI
+        }
     }
 
     @IBAction func didTapView(_ sender: Any) {
@@ -52,6 +54,8 @@ class ViewController: UIViewController, CNContactPickerDelegate {
     }
 
     @IBAction func withDefaultPickerUIDidChange(_ sender: Any) {
-        self.textField.withDefaultPickerUI = self.withDefaultPickerUISwitch.isOn
+        if #available(iOS 11.0, *) {
+            self.textField.withDefaultPickerUI = self.withDefaultPickerUISwitch.isOn
+        }
     }
 }

--- a/examples/AsYouType/Sample/ViewController.swift
+++ b/examples/AsYouType/Sample/ViewController.swift
@@ -43,4 +43,19 @@ class ViewController: UIViewController, CNContactPickerDelegate {
             self.textField.placeholder = "Enter phone number"
         }
     }
+
+    @IBAction func withPrefixDidChange(_ sender: Any) {
+        self.textField.withPrefix = self.withPrefixSwitch.isOn
+    }
+
+    @IBAction func withFlagDidChange(_ sender: Any) {
+        self.textField.withFlag = self.withFlagSwitch.isOn
+    }
+
+    @IBAction func withExamplePlaceholderDidChange(_ sender: Any) {
+        self.textField.withExamplePlaceholder = self.withExamplePlaceholderSwitch.isOn
+        if !self.textField.withExamplePlaceholder {
+            self.textField.placeholder = "Enter phone number"
+        }
+    }
 }


### PR DESCRIPTION
As I mentioned in [here](https://github.com/marmelroy/PhoneNumberKit/issues/308#issuecomment-547217064), this PR add's a picker UI that is either presented or pushed based of a the new `withDefaultPickerUI` flag on PhoneNumberTextField. 

It displays the list based off the country codes returned from PhoneNumberKit's `allCountries` function. It includes search based of the dialing prefix, country full name, and country code (`DE` for Germany).

The functionality includes at least 1 issue I know of, since multiple countries are on the `+1` prefix, when selecting Canada, for example after the Picker is dismissed, the flag in the textfield will be the US flag. This seems to stem from some behaviour internal to how `PhoneNumberTextField` handles `defaultRegion`. I think this is the same issue I mentioned in #309. Any help resolving this would be great, I'm not sure how to resolve this.

![2019-10-29 11 33 29](https://user-images.githubusercontent.com/7651280/67730196-075e9200-fa40-11e9-9ec0-234565efe360.gif)