### PR TITLE
Updated logic for RU region

### DIFF
--- a/PhoneNumberKit/UI/TextField.swift
+++ b/PhoneNumberKit/UI/TextField.swift
@@ -234,7 +234,14 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
     open func updatePlaceholder() {
         guard self.withExamplePlaceholder else { return }
         if isEditing, !(self.text ?? "").isEmpty { return } // No need to update a placeholder while the placeholder isn't showing
-        let format = self.withPrefix ? PhoneNumberFormat.international : .national
+        
+        let format: PhoneNumberFormat
+        if self.currentRegion == "RU" {
+            format = self.withPrefix ? PhoneNumberFormat.national : .international
+        } else {
+            format = self.withPrefix ? PhoneNumberFormat.international : .national
+        }
+                
         let example = self.phoneNumberKit.getFormattedExampleNumber(forCountry: self.currentRegion, withFormat: format, withPrefix: self.withPrefix) ?? "12345678"
 
         let font = self.font ?? UIFont.preferredFont(forTextStyle: .body)


### PR DESCRIPTION
When I set `phoneNumberTextField.withPrefix = false`, for RU region was show prefix like **8**, what is no correct

<img width="263" alt="Screenshot 2019-12-02 19 24 16" src="https://user-images.githubusercontent.com/28268405/69976013-5b75fe00-1539-11ea-8521-7de498028951.png">

After updated logic, look like this

<img width="264" alt="Screenshot 2019-12-02 19 26 38" src="https://user-images.githubusercontent.com/28268405/69976327-d9d2a000-1539-11ea-89e6-d064b65d5995.png">

i.e., correct)