### PR TITLE
Make project compile with Xcode 10.x

### DIFF
--- a/PhoneNumberKit/UI/TextField.swift
+++ b/PhoneNumberKit/UI/TextField.swift
@@ -239,6 +239,7 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
 
         let font = self.font ?? UIFont.preferredFont(forTextStyle: .body)
         let ph = NSMutableAttributedString(string: example, attributes: [.font: font])
+        #if compiler(>=5.1)
         if #available(iOS 13.0, *), self.withPrefix {
             // because the textfield will automatically handle insert & removal of the international prefix we make the
             // prefix darker to indicate non default behaviour to users, this behaviour currently only happens on iOS 13
@@ -248,6 +249,7 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
             ph.addAttribute(.foregroundColor, value: UIColor.secondaryLabel, range: NSRange(..<firstSpaceIndex, in: example))
             ph.addAttribute(.foregroundColor, value: UIColor.tertiaryLabel, range: NSRange(firstSpaceIndex..., in: example))
         }
+        #endif
         self.attributedPlaceholder = ph
     }
 


### PR DESCRIPTION
Make project compile with Xcode 10.x as some projects still not migrated to use Xcode 11 but they need the latest `libphonenumber` metadata included only in the latest version.