### PR TITLE
Fix dequeueReusableCell crash because Cell is not registered

### DIFF
--- a/PhoneNumberKit/UI/CountryCodePickerViewController.swift
+++ b/PhoneNumberKit/UI/CountryCodePickerViewController.swift
@@ -76,6 +76,7 @@ public class CountryCodePickerViewController: UITableViewController {
         self.phoneNumberKit = phoneNumberKit
         self.commonCountryCodes = commonCountryCodes
         super.init(style: .grouped)
+        self.commonInit()
     }
 
     required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
`CountryCodePickerViewController` did not register Cell with `init(phoneNumberKit:)` and it causes app crash if `withDefaultPickerUI` is true.