### PR TITLE
Silences CoreTelephony logging in iOS Simulator

### DIFF
--- a/PhoneNumberKit/PhoneNumberKit.swift
+++ b/PhoneNumberKit/PhoneNumberKit.swift
@@ -217,7 +217,7 @@ public final class PhoneNumberKit: NSObject {
     ///
     /// - returns: A computed value for the user's current region - based on the iPhone's carrier and if not available, the device region.
     public class func defaultRegionCode() -> String {
-#if os(iOS) && !targetEnvironment(macCatalyst)
+#if os(iOS) && !targetEnvironment(simulator) && !targetEnvironment(macCatalyst)
         let networkInfo = CTTelephonyNetworkInfo()
         let carrier = networkInfo.subscriberCellularProvider
         if let isoCountryCode = carrier?.isoCountryCode {


### PR DESCRIPTION
Reference: https://github.com/marmelroy/PhoneNumberKit/issues/246

Silences CoreTelephony logging in iOS Simulator by extending the existing `#if`-checking to exclude that environment.

CT isn't supported in iOS Simulator. Each time `PhoneNumberKit.swift`'s `defaultRegionCode()` calls `CTTelephonyNetworkInfo()`, the following is logged:

`NSCocoaErrorDomain Code=4099 "The connection to service on pid 0 named com.apple.commcenter.coretelephony.xpc was invalidated."` 