### PR TITLE
Fix flag and region always set to US on +1 country code phone numbers

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/PhoneNumberKit/PartialFormatter.swift
+++ b/PhoneNumberKit/PartialFormatter.swift
@@ -58,7 +58,13 @@ public final class PartialFormatter {
     // MARK: Status
 
     public var currentRegion: String {
-        return self.currentMetadata?.codeID ?? self.defaultRegion
+        if self.phoneNumberKit.countryCode(for: self.defaultRegion) != 1 {
+            return currentMetadata?.codeID ?? "US"
+        } else {
+            return self.currentMetadata?.countryCode == 1
+                ? self.defaultRegion
+                : self.currentMetadata?.codeID ?? self.defaultRegion
+        }
     }
 
     public func nationalNumber(from rawNumber: String) -> String {


### PR DESCRIPTION
**Quality of life fix for people residing in countries with +1 country code.**

Currently, the flag and current region is always set to US if you are trying to enter a phone number with a +1 region code.

This fix just takes the defaultRegion rather than the currentRegion when country code is +1

This should allow people using the PhoneNumberTextField residing in canada, carribean, etc... to actually see their country flag when entering a phone number. 