### PR TITLE
Update readme to include workaround for SPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,3 +134,7 @@ github "marmelroy/PhoneNumberKit"
 source 'https://github.com/CocoaPods/Specs.git'
 pod 'PhoneNumberKit', '~> 3.1'
 ```
+
+### Setting up with [Swift Package Manager](https://swiftpm.co/?query=PhoneNumberKit)
+As of swift 5.1, Swift Package Manager does not support resources bundled with Swift packages.
+Becuase of this, you need to manually copy `PhoneNumberMetadata.json` into your project.


### PR DESCRIPTION
When using SPM, PhoneNumberKit cannot see the `PhoneNumberMetadata.json` file. This is a limitation with SPM and will be fixed in [Swift 5.3 ](https://forums.swift.org/t/se-0271-package-manager-resources/30730/).

In the mean time, users should know that to use SPM they need to copy the `PhoneNumberMetadata.json` into their own project.