### PR TITLE
Add phoneNumber property to PhoneNumberTextField.

### DIFF
--- a/PhoneNumberKit.xcodeproj/project.pbxproj
+++ b/PhoneNumberKit.xcodeproj/project.pbxproj
@@ -25,7 +25,7 @@
 		342548F01BE7EED500FBE524 /* MetadataTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 342548EF1BE7EED500FBE524 /* MetadataTypes.swift */; };
 		3435CCA01BBFF66F003F953B /* PhoneNumberMetadata.json in Resources */ = {isa = PBXBuildFile; fileRef = 3435CC951BBFF66F003F953B /* PhoneNumberMetadata.json */; };
 		343B850C1C62A25600918E46 /* PartialFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 343B850A1C62A25600918E46 /* PartialFormatter.swift */; };
-		343B850D1C62A25600918E46 /* TextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 343B850B1C62A25600918E46 /* TextField.swift */; };
+		343B850D1C62A25600918E46 /* PhoneNumberTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 343B850B1C62A25600918E46 /* PhoneNumberTextField.swift */; };
 		34566C9A1BC112C500715E6B /* RegexManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34566C991BC112C500715E6B /* RegexManager.swift */; };
 		346922671BC01DCC0023482F /* MetadataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346922661BC01DCC0023482F /* MetadataManager.swift */; };
 		346922691BC023A60023482F /* PhoneNumberKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346922681BC023A60023482F /* PhoneNumberKit.swift */; };
@@ -76,7 +76,7 @@
 		C6DF6CDE1D1B18D800259F4B /* PhoneNumberKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346922681BC023A60023482F /* PhoneNumberKit.swift */; };
 		C6DF6CDF1D1B18D800259F4B /* PhoneNumberParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 342418811BB70F5200EE70E7 /* PhoneNumberParser.swift */; };
 		C6DF6CE01D1B18D800259F4B /* RegexManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34566C991BC112C500715E6B /* RegexManager.swift */; };
-		C9D81F822348025700B75AB7 /* TextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D81F812348025700B75AB7 /* TextFieldTests.swift */; };
+		C9D81F822348025700B75AB7 /* PhoneNumberTextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D81F812348025700B75AB7 /* PhoneNumberTextFieldTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -105,7 +105,7 @@
 		342548EF1BE7EED500FBE524 /* MetadataTypes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MetadataTypes.swift; sourceTree = "<group>"; };
 		3435CC951BBFF66F003F953B /* PhoneNumberMetadata.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = PhoneNumberMetadata.json; sourceTree = "<group>"; };
 		343B850A1C62A25600918E46 /* PartialFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PartialFormatter.swift; sourceTree = "<group>"; usesTabs = 0; };
-		343B850B1C62A25600918E46 /* TextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TextField.swift; path = UI/TextField.swift; sourceTree = "<group>"; };
+		343B850B1C62A25600918E46 /* PhoneNumberTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PhoneNumberTextField.swift; path = UI/PhoneNumberTextField.swift; sourceTree = "<group>"; usesTabs = 0; };
 		34566C991BC112C500715E6B /* RegexManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegexManager.swift; sourceTree = "<group>"; };
 		346922661BC01DCC0023482F /* MetadataManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MetadataManager.swift; sourceTree = "<group>"; };
 		346922681BC023A60023482F /* PhoneNumberKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhoneNumberKit.swift; sourceTree = "<group>"; };
@@ -120,7 +120,7 @@
 		C6DF6C911D1B120400259F4B /* PhoneNumberKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PhoneNumberKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C6DF6CA71D1B145300259F4B /* PhoneNumberKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PhoneNumberKit.h; sourceTree = "<group>"; };
 		C6DF6CCC1D1B18B000259F4B /* PhoneNumberKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PhoneNumberKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		C9D81F812348025700B75AB7 /* TextFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldTests.swift; sourceTree = "<group>"; };
+		C9D81F812348025700B75AB7 /* PhoneNumberTextFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneNumberTextFieldTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -219,7 +219,7 @@
 				34AA66011BDD160B00467912 /* Constants.swift */,
 				3420CF5D1BE8959F00FAE34F /* Formatter.swift */,
 				343B850A1C62A25600918E46 /* PartialFormatter.swift */,
-				343B850B1C62A25600918E46 /* TextField.swift */,
+				343B850B1C62A25600918E46 /* PhoneNumberTextField.swift */,
 				5D14267C238F5842002DD197 /* CountryCodePickerViewController.swift */,
 				342418811BB70F5200EE70E7 /* PhoneNumberParser.swift */,
 				1B0651161E2AD698006AE849 /* PhoneNumberFormatter.swift */,
@@ -237,7 +237,7 @@
 				346EF14D1C69C688008C7306 /* PartialFormatterTests.swift */,
 				34776AA71BE2BF1100400790 /* PhoneNumberKitParsingTests.swift */,
 				342418751BB6E5A000EE70E7 /* Info.plist */,
-				C9D81F812348025700B75AB7 /* TextFieldTests.swift */,
+				C9D81F812348025700B75AB7 /* PhoneNumberTextFieldTests.swift */,
 			);
 			path = PhoneNumberKitTests;
 			sourceTree = "<group>";
@@ -484,7 +484,7 @@
 				342418821BB70F5200EE70E7 /* PhoneNumberParser.swift in Sources */,
 				346922671BC01DCC0023482F /* MetadataManager.swift in Sources */,
 				3420CF5E1BE8959F00FAE34F /* Formatter.swift in Sources */,
-				343B850D1C62A25600918E46 /* TextField.swift in Sources */,
+				343B850D1C62A25600918E46 /* PhoneNumberTextField.swift in Sources */,
 				5D14267D238F5842002DD197 /* CountryCodePickerViewController.swift in Sources */,
 				3417BD6B2210AC4900477EE7 /* MetadataParsing.swift in Sources */,
 				346922691BC023A60023482F /* PhoneNumberKit.swift in Sources */,
@@ -505,7 +505,7 @@
 				34776AA81BE2BF1100400790 /* PhoneNumberKitParsingTests.swift in Sources */,
 				342418741BB6E5A000EE70E7 /* PhoneNumberKitTests.swift in Sources */,
 				346EF14E1C69C688008C7306 /* PartialFormatterTests.swift in Sources */,
-				C9D81F822348025700B75AB7 /* TextFieldTests.swift in Sources */,
+				C9D81F822348025700B75AB7 /* PhoneNumberTextFieldTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PhoneNumberKit/UI/PhoneNumberTextField.swift
+++ b/PhoneNumberKit/UI/PhoneNumberTextField.swift
@@ -1,5 +1,5 @@
 //
-//  TextField.swift
+//  PhoneNumberTextField.swift
 //  PhoneNumberKit
 //
 //  Created by Roy Marmelstein on 07/11/2015.
@@ -156,6 +156,19 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
         }
     }
 
+    /**
+     Returns the current valid phone number.
+     - returns: PhoneNumber?
+     */
+    public var phoneNumber: PhoneNumber? {
+        guard let rawNumber = self.text else { return nil }
+        do {
+            return try phoneNumberKit.parse(rawNumber, withRegion: currentRegion)
+        } catch {
+            return nil
+        }
+    }
+
     open override func layoutSubviews() {
         if self.withFlag { // update the width of the flagButton automatically, iOS <13 doesn't handle this for you
             let width = self.flagButton.systemLayoutSizeFitting(bounds.size).width
@@ -248,14 +261,14 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
     open func updatePlaceholder() {
         guard self.withExamplePlaceholder else { return }
         if isEditing, !(self.text ?? "").isEmpty { return } // No need to update a placeholder while the placeholder isn't showing
-        
+
         let format: PhoneNumberFormat
         if self.currentRegion == "RU" {
             format = self.withPrefix ? PhoneNumberFormat.national : .international
         } else {
             format = self.withPrefix ? PhoneNumberFormat.international : .national
         }
-                
+
         let example = self.phoneNumberKit.getFormattedExampleNumber(forCountry: self.currentRegion, withFormat: format, withPrefix: self.withPrefix) ?? "12345678"
 
         let font = self.font ?? UIFont.preferredFont(forTextStyle: .body)

--- a/PhoneNumberKitTests/PhoneNumberTextFieldTests.swift
+++ b/PhoneNumberKitTests/PhoneNumberTextFieldTests.swift
@@ -1,5 +1,5 @@
 //
-//  TextFieldTests.swift
+//  PhoneNumberTextFieldTests.swift
 //  PhoneNumberKitTests
 //
 //  Created by Travis Kaufman on 10/4/19.
@@ -12,7 +12,7 @@
 import UIKit
 import XCTest
 
-class TextFieldTests: XCTestCase {
+class PhoneNumberTextFieldTests: XCTestCase {
     func testWorksWithPhoneNumberKitInstance() {
         let pnk = PhoneNumberKit()
         let tf = PhoneNumberTextField(withPhoneNumberKit: pnk)
@@ -28,6 +28,15 @@ class TextFieldTests: XCTestCase {
         tf.text = "4125551212"
         XCTAssertEqual(tf.text, "(412) 555-1212")
     }
+
+	func testPhoneNumberProperty() {
+		let pnk = PhoneNumberKit()
+		let tf = PhoneNumberTextField(withPhoneNumberKit: pnk)
+		tf.text = "4125551212"
+		XCTAssertNotNil(tf.phoneNumber)
+		tf.text = ""
+		XCTAssertNil(tf.phoneNumber)
+	}
 }
 
 #endif


### PR DESCRIPTION
- This should allow users to conveniently access the PhoneNumber without having to manually parse it themselves.
- Test cases for this property added.
- Also renamed 'TextField' file to PhoneNumberTextField.
- Also renamed 'TextFieldTests' file to PhoneNumberTextFieldTests.