### PR TITLE
forceModalPresentation should dimiss when selecting a country

### DIFF
--- a/PhoneNumberKit/UI/PhoneNumberTextField.swift
+++ b/PhoneNumberKit/UI/PhoneNumberTextField.swift
@@ -469,7 +469,7 @@ extension PhoneNumberTextField: CountryCodePickerDelegate {
         updateFlag()
         updatePlaceholder()
 
-        if let nav = containingViewController?.navigationController {
+        if let nav = containingViewController?.navigationController, !PhoneNumberKit.CountryCodePicker.forceModalPresentation {
             nav.popViewController(animated: true)
         } else {
             containingViewController?.dismiss(animated: true)


### PR DESCRIPTION
Currently when selecting a country with `forceModalPresentation` enable it pops the stack but should dismiss instead.

Resolution is to check for `forceModalPresentation` just like presenting does.