### PR TITLE
Dismiss CountryCodePickerViewController properly when presented modal…

### DIFF
--- a/PhoneNumberKit/UI/PhoneNumberTextField.swift
+++ b/PhoneNumberKit/UI/PhoneNumberTextField.swift
@@ -492,7 +492,8 @@ extension PhoneNumberTextField: CountryCodePickerDelegate {
         updateFlag()
         updatePlaceholder()
 
-        if let nav = containingViewController?.navigationController, !PhoneNumberKit.CountryCodePicker.forceModalPresentation {
+        if !PhoneNumberKit.CountryCodePicker.forceModalPresentation,
+            let nav = containingViewController?.navigationController, !PhoneNumberKit.CountryCodePicker.forceModalPresentation {
             nav.popViewController(animated: true)
         } else {
             containingViewController?.dismiss(animated: true)


### PR DESCRIPTION
…ly on a navigation controller

Currently, when CountryCodePickerViewController is presented modally over a navigation controller and a country is selected, the PhoneNumberTextField pops the top view controller in the navigation controller, instead of dismissing the modally presented CountryCodePickerViewController. This commit fixes that by checking is CountryCodePickerViewController is presented modally before popping the navigation controller. 