### PR TITLE
Report when metadata could not be loaded

### DIFF
--- a/PhoneNumberKit/MetadataManager.swift
+++ b/PhoneNumberKit/MetadataManager.swift
@@ -50,7 +50,9 @@ final class MetadataManager {
             if let jsonData = jsonData, let metadata: PhoneNumberMetadata = try? jsonDecoder.decode(PhoneNumberMetadata.self, from: jsonData) {
                 territoryArray = metadata.territories
             }
-        } catch {}
+        } catch {
+            debugPrint("ERROR: Unable to load PhoneNumberMetadata.json resource: \(error.localizedDescription)")
+        }
         return territoryArray
     }
 


### PR DESCRIPTION
Currently this exception is being swallowed, which is resulting in broken functionality as reported in #359.

This change is a bare minimum. It really should be reported to the OS log. But at least with this change it will no longer be completely silent.
