### PR TITLE
modernize: min deployment iOS 9, VALID_ARCHS = arm64/x86_64 only

### DIFF
--- a/PhoneNumberKit.xcodeproj/project.pbxproj
+++ b/PhoneNumberKit.xcodeproj/project.pbxproj
@@ -716,6 +716,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VALID_ARCHS = "armv7s arm64 arm64e x86_64";
 			};
 			name = Debug;
 		};
@@ -738,6 +739,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				VALID_ARCHS = "armv7s arm64 arm64e x86_64";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
currently, when using Xcode 12 / Swift 5.3 to create an archive using
PhoneNumberKit (or to archive itself) for `any iOS Device`, the build
fails with:

  Undefined symbols for architecture armv7:
    "type metadata for Swift._StringObject.Variant", referenced from:
        outlined init with take of Swift._StringObject.Variant in
        CountryCodePickerViewController.o

thus, in order for ld to do its job finding this metadata, we need to
confine our build to not build for `armv7` .

unfortunately, using the Xcode UI to remove `armv7` from VALID_ARCHS
results in a VALID_ARCHS setting that causes the mac-catalyst build
to fail.  (as evidenced when building using pull-request #388 before
it was reverted in pull-request #389.)

so this VALID_ARCHS was achieved by using the Xcode UI to "remove"
`armv7` (thus resulting in `armv7s arm64 arm64e`) and then adding
`x86_64` so that mac-catalyst would build.

armv7s still supports iPhone 5, 5c .