### PR TITLE
Updating default region of partial formatter to new value when the default region value of phone number text field gets updated.

### DIFF
--- a/PhoneNumberKit/UI/PhoneNumberTextField.swift
+++ b/PhoneNumberKit/UI/PhoneNumberTextField.swift
@@ -53,7 +53,9 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
                 please override defaultRegion in a subclass instead.
             """
         )
-        set {}
+        set {
+            self.partialFormatter.defaultRegion = newValue
+        }
     }
 
     public var withPrefix: Bool = true {


### PR DESCRIPTION
Whenever the default region property of the phone number text field gets updated (via being overridden), the default region property of the equivalent partial formatter needs to be updated as well. Currently, I am doing this in my app's codebase. However, I believe the user shouldn't worry about such core implementation of your library inside the app layer. 

The use case I stumbled upon was having a normal text field for setting the country code and upon that change, I do modify the library's default region, country .. etc. However, the partial formatter's default region was not being updated causing some digits not to be written/added when typed in the phone number text field. 