### PR TITLE
Fix region code for multiple countries sharing a calling code

### DIFF
--- a/PhoneNumberKit/MetadataManager.swift
+++ b/PhoneNumberKit/MetadataManager.swift
@@ -23,7 +23,13 @@ final class MetadataManager {
         self.territories = self.populateTerritories(metadataCallback: metadataCallback)
         for item in self.territories {
             var currentTerritories: [MetadataTerritory] = self.territoriesByCode[item.countryCode] ?? [MetadataTerritory]()
-            currentTerritories.append(item)
+            // In the case of multiple countries sharing a calling code, such as the NANPA countries,
+            // the one indicated with "isMainCountryForCode" in the metadata should be first.
+            if item.mainCountryForCode {
+                currentTerritories.insert(item, at: 0)
+            } else {
+                currentTerritories.append(item)
+            }
             self.territoriesByCode[item.countryCode] = currentTerritories
             if self.mainTerritoryByCode[item.countryCode] == nil || item.mainCountryForCode == true {
                 self.mainTerritoryByCode[item.countryCode] = item

--- a/PhoneNumberKitTests/PhoneNumberKitTests.swift
+++ b/PhoneNumberKitTests/PhoneNumberKitTests.swift
@@ -417,4 +417,15 @@ class PhoneNumberKitTests: XCTestCase {
         }
         XCTAssertEqual(self.phoneNumberKit.getRegionCode(of: phoneNumber), "IT")
     }
+    
+    // In the case of multiple
+    // countries sharing a calling code, the one
+    // indicated with "isMainCountryForCode" in the metadata should be first.
+    func testGetRegionCodeForTollFreeFromUS() {
+        guard let phoneNumber = try? phoneNumberKit.parse("+1 888 579 4458") else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(self.phoneNumberKit.getRegionCode(of: phoneNumber), "US")
+    }
 }


### PR DESCRIPTION
From [CountryCodeToRegionCodeMap](https://github.com/google/libphonenumber/blob/0dd0f034ff89d00f4d67cee8d8b88b27be4931bd/java/libphonenumber/src/com/google/i18n/phonenumbers/CountryCodeToRegionCodeMap.java), it says:

> // In the case of multiple
  // countries sharing a calling code, such as the NANPA countries, the one
  // indicated with "isMainCountryForCode" in the metadata should be first.

So I think this lib should do the same.