### PR TITLE
Allow dynamic linking when using Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.3
 
 import PackageDescription
 
@@ -8,7 +8,19 @@ let package = Package(
         .library(name: "PhoneNumberKit", targets: ["PhoneNumberKit"])
     ],
     targets: [
-        .target(name: "PhoneNumberKit", path: "PhoneNumberKit", exclude: []),
-        .testTarget(name: "PhoneNumberKitTests", dependencies: ["PhoneNumberKit"], path: "PhoneNumberKitTests")
+        .target(name: "PhoneNumberKit",
+                path: "PhoneNumberKit",
+                exclude: ["Resources/Original",
+                         "Resources/README.md",
+                         "Resources/update.sh",
+                         "Info.plist"],
+                sources: nil,
+                resources: [
+                    .process("Resources/PhoneNumberMetadata.json")
+                ]),
+        .testTarget(name: "PhoneNumberKitTests",
+                    dependencies: ["PhoneNumberKit"],
+                    path: "PhoneNumberKitTests",
+                    exclude: ["Info.plist"])
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -5,16 +5,17 @@ import PackageDescription
 let package = Package(
     name: "PhoneNumberKit",
     products: [
-        .library(name: "PhoneNumberKit", targets: ["PhoneNumberKit"])
+        .library(name: "PhoneNumberKit", targets: ["PhoneNumberKit"]),
+        .library(name: "PhoneNumberKit-Static", type: .static, targets: ["PhoneNumberKit"]),
+        .library(name: "PhoneNumberKit-Dynamic", type: .dynamic, targets: ["PhoneNumberKit"])
     ],
     targets: [
         .target(name: "PhoneNumberKit",
                 path: "PhoneNumberKit",
                 exclude: ["Resources/Original",
-                         "Resources/README.md",
-                         "Resources/update.sh",
-                         "Info.plist"],
-                sources: nil,
+                          "Resources/README.md",
+                          "Resources/update.sh",
+                          "Info.plist"],
                 resources: [
                     .process("Resources/PhoneNumberMetadata.json")
                 ]),

--- a/PhoneNumberKit/PhoneNumberKit.swift
+++ b/PhoneNumberKit/PhoneNumberKit.swift
@@ -316,7 +316,7 @@ public final class PhoneNumberKit: NSObject {
     ///
     /// - returns: an optional Data representation of the metadata.
     public static func defaultMetadataCallback() throws -> Data? {
-        let frameworkBundle = Bundle(for: PhoneNumberKit.self)
+        let frameworkBundle = Bundle.module
         guard let jsonPath = frameworkBundle.path(forResource: "PhoneNumberMetadata", ofType: "json") else {
             throw PhoneNumberError.metadataNotFound
         }

--- a/README.md
+++ b/README.md
@@ -4,22 +4,24 @@
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 
 # PhoneNumberKit
+
 Swift 5.0 framework for parsing, formatting and validating international phone numbers.
 Inspired by Google's libphonenumber.
 
-[Migrating from PhoneNumberKit 0.x? See the migration guide.](https://github.com/marmelroy/PhoneNumberKit/blob/master/Documentation/OXMIGRATIONGUIDE.md)  
+[Migrating from PhoneNumberKit 0.x? See the migration guide.](https://github.com/marmelroy/PhoneNumberKit/blob/master/Documentation/OXMIGRATIONGUIDE.md)
+
 ## Features
 
-| |Features |
---------------------------|------------------------------------------------------------
-:phone: | Validate, normalize and extract the elements of any phone number string.
-:100: | Simple Swift syntax and a lightweight readable codebase.
-:checkered_flag: | Fast. 1000 parses -> ~0.4 seconds.
-:books: | Best-in-class metadata from Google's libPhoneNumber project.
-:trophy: | Fully tested to match the accuracy of Google's JavaScript implementation of libPhoneNumber.
-:iphone: | Built for iOS. Automatically grabs the default region code from the phone.
-📝 | Editable (!) AsYouType formatter for UITextField.
-:us: | Convert country codes to country names and vice versa
+|                  | Features                                                                                    |
+| ---------------- | ------------------------------------------------------------------------------------------- |
+| :phone:          | Validate, normalize and extract the elements of any phone number string.                    |
+| :100:            | Simple Swift syntax and a lightweight readable codebase.                                    |
+| :checkered_flag: | Fast. 1000 parses -> ~0.4 seconds.                                                          |
+| :books:          | Best-in-class metadata from Google's libPhoneNumber project.                                |
+| :trophy:         | Fully tested to match the accuracy of Google's JavaScript implementation of libPhoneNumber. |
+| :iphone:         | Built for iOS. Automatically grabs the default region code from the phone.                  |
+| 📝               | Editable (!) AsYouType formatter for UITextField.                                           |
+| :us:             | Convert country codes to country names and vice versa                                       |
 
 ## Usage
 
@@ -38,6 +40,7 @@ let phoneNumberKit = PhoneNumberKit()
 ```
 
 To parse a string, use the parse function. The region code is automatically computed but can be overridden if needed. PhoneNumberKit automatically does a hard type validation to ensure that the object created is valid, this can be quite costly performance-wise and can be turned off if needed.
+
 ```swift
 do {
     let phoneNumber = try phoneNumberKit.parse("+33 6 89 017383")
@@ -49,6 +52,7 @@ catch {
 ```
 
 If you need to parse and validate a large amount of numbers at once, PhoneNumberKit has a special, lightning fast array parsing function. The default region code is automatically computed but can be overridden if needed. Here you can also ignore hard type validation if it is not necessary. Invalid numbers are ignored in the resulting array.
+
 ```swift
 let rawNumberArray = ["0291 12345678", "+49 291 12345678", "04134 1234", "09123 12345"]
 let phoneNumbers = phoneNumberKit.parse(rawNumberArray)
@@ -56,6 +60,7 @@ let phoneNumbersCustomDefaultRegion = phoneNumberKit.parse(rawNumberArray, withR
 ```
 
 PhoneNumber objects are immutable Swift structs with the following properties:
+
 ```swift
 phoneNumber.numberString
 phoneNumber.countryCode
@@ -65,6 +70,7 @@ phoneNumber.type // e.g Mobile or Fixed
 ```
 
 Formatting a PhoneNumber object into a string is also very easy
+
 ```swift
 phoneNumberKit.format(phoneNumber, toType: .e164) // +61236618300
 phoneNumberKit.format(phoneNumber, toType: .international) // +61 2 3661 8300
@@ -78,10 +84,12 @@ phoneNumberKit.format(phoneNumber, toType: .national) // (02) 3661 8300
 To use the AsYouTypeFormatter, just replace your UITextField with a PhoneNumberTextField (if you are using Interface Builder make sure the module field is set to PhoneNumberKit).
 
 You can customize your TextField UI in the following ways
+
 - `withFlag` will display the country code for the `currentRegion`. The `flagButton` is displayed in the `leftView` of the text field with it's size set based off your text size.
 - `withExamplePlaceholder` uses `attributedPlaceholder` to show an example number for the `currentRegion`. In addition when `withPrefix` is set, the country code's prefix will automatically be inserted and removed when editing changes.
 
 PhoneNumberTextField automatically formats phone numbers and gives the user full editing capabilities. If you want to customize you can use the PartialFormatter directly. The default region code is automatically computed but can be overridden if needed (see the example given below).
+
 ```swift
 class MyGBTextField: PhoneNumberTextField {
     override var defaultRegion: String {
@@ -100,6 +108,7 @@ PartialFormatter().formatPartial("+336895555") // +33 6 89 55 55
 ```
 
 You can also query countries for a dialing code or the dialing code for a given country
+
 ```swift
 phoneNumberKit.countries(withCode: 33)
 phoneNumberKit.countryCode(for: "FR")
@@ -108,6 +117,7 @@ phoneNumberKit.countryCode(for: "FR")
 ## Need more customization?
 
 You can access the metadata powering PhoneNumberKit yourself, this enables you to program any behaviours as they may be implemented in PhoneNumberKit itself. It does mean you are exposed to the less polished interface of the underlying file format. If you program something you find useful please push it upstream!
+
 ```swift
 phoneNumberKit.metadata(for: "AU")?.mobile?.exampleNumber // 412345678
 ```
@@ -130,11 +140,13 @@ github "marmelroy/PhoneNumberKit"
 ```
 
 ### Setting up with [CocoaPods](http://cocoapods.org/?q=PhoneNumberKit)
+
 ```ruby
 source 'https://github.com/CocoaPods/Specs.git'
 pod 'PhoneNumberKit', '~> 3.1'
 ```
 
 ### Setting up with [Swift Package Manager](https://swiftpm.co/?query=PhoneNumberKit)
-As of swift 5.1, Swift Package Manager does not support resources bundled with Swift packages.
-Becuase of this, you need to manually copy `PhoneNumberMetadata.json` into your project.
+
+As of swift 5.3, Swift Package Manager does support resources bundled with Swift packages.
+Becuase of this, you no longer need to manually copy `PhoneNumberMetadata.json` into your project.


### PR DESCRIPTION
This adds the ability to choose between static, dynamic and automatic linking when integrating PhoneNumberKit using SwiftPackage Manager. This is helpful when including in main and sub-projects resolving:
```
Swift package product 'PhoneNumberKit' is linked as static library by 'XXXX' and 'YYYY'. This will result in duplication of code
```

Note that this pull request already contains changes from https://github.com/marmelroy/PhoneNumberKit/pull/381