### PR TITLE
Xcode12.1: update .xcscheme & project.pbxproj 1210

### DIFF
--- a/PhoneNumberKit.xcodeproj/project.pbxproj
+++ b/PhoneNumberKit.xcodeproj/project.pbxproj
@@ -391,7 +391,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 1200;
+				LastUpgradeCheck = 1210;
 				ORGANIZATIONNAME = "Roy Marmelstein";
 				TargetAttributes = {
 					342418631BB6E5A000EE70E7 = {

--- a/PhoneNumberKit.xcodeproj/xcshareddata/xcschemes/PhoneNumberKit-macOS.xcscheme
+++ b/PhoneNumberKit.xcodeproj/xcshareddata/xcschemes/PhoneNumberKit-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1210"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/PhoneNumberKit.xcodeproj/xcshareddata/xcschemes/PhoneNumberKit-tvOS.xcscheme
+++ b/PhoneNumberKit.xcodeproj/xcshareddata/xcschemes/PhoneNumberKit-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1210"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/PhoneNumberKit.xcodeproj/xcshareddata/xcschemes/PhoneNumberKit-watchOS.xcscheme
+++ b/PhoneNumberKit.xcodeproj/xcshareddata/xcschemes/PhoneNumberKit-watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1210"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/PhoneNumberKit.xcodeproj/xcshareddata/xcschemes/PhoneNumberKit.xcscheme
+++ b/PhoneNumberKit.xcodeproj/xcshareddata/xcschemes/PhoneNumberKit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1210"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
the only changes recommended by Xcode 12.1 were minimum
deployment target to SDK version 12.  REJECTED for now.