### PR TITLE
Add support for armv7

### DIFF
--- a/PhoneNumberKit.xcodeproj/project.pbxproj
+++ b/PhoneNumberKit.xcodeproj/project.pbxproj
@@ -728,7 +728,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				VALID_ARCHS = "armv7s arm64 arm64e x86_64";
+				VALID_ARCHS = "armv7 armv7s arm64 arm64e x86_64";
 			};
 			name = Debug;
 		};
@@ -751,7 +751,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				VALID_ARCHS = "armv7s arm64 arm64e x86_64";
+				VALID_ARCHS = "armv7 armv7s arm64 arm64e x86_64";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
When targeting iOS 10, we get error that PhoneNumberKit doesn't contain symbols for armv7 architecture when compiled using Carthage.

This PR adds armv7 to VALID_ARCHS.

> error: The linked framework 'PhoneNumberKit.framework' is missing one or more architectures required by this target: armv7. (in target 'App' from project 'App')
