### PR TITLE
Use decodeIfPresent method for optional values instead of optional try

### DIFF
--- a/PhoneNumberKit/MetadataParsing.swift
+++ b/PhoneNumberKit/MetadataParsing.swift
@@ -46,32 +46,32 @@ public extension MetadataTerritory {
         let code = try! container.decode(String.self, forKey: .countryCode)
         countryCode = UInt64(code)!
         mainCountryForCode = container.decodeBoolString(forKey: .mainCountryForCode)
-        let possibleNationalPrefixForParsing: String? = try? container.decode(String.self, forKey: .nationalPrefixForParsing)
-        let possibleNationalPrefix: String? = try? container.decode(String.self, forKey: .nationalPrefix)
+        let possibleNationalPrefixForParsing: String? = try container.decodeIfPresent(String.self, forKey: .nationalPrefixForParsing)
+        let possibleNationalPrefix: String? = try container.decodeIfPresent(String.self, forKey: .nationalPrefix)
         nationalPrefix = possibleNationalPrefix
         nationalPrefixForParsing = (possibleNationalPrefixForParsing == nil && possibleNationalPrefix != nil) ? nationalPrefix : possibleNationalPrefixForParsing
-        nationalPrefixFormattingRule = try? container.decode(String.self, forKey: .nationalPrefixFormattingRule)
+        nationalPrefixFormattingRule = try container.decodeIfPresent(String.self, forKey: .nationalPrefixFormattingRule)
         let availableFormats = try? container.nestedContainer(keyedBy: CodingKeys.self, forKey: .availableFormats)
         let temporaryFormatList: [MetadataPhoneNumberFormat] = availableFormats?.decodeArrayOrObject(forKey: .numberFormats) ?? [MetadataPhoneNumberFormat]()
         numberFormats = temporaryFormatList.withDefaultNationalPrefixFormattingRule(nationalPrefixFormattingRule)
 
         // Default parsing logic
-        internationalPrefix = try? container.decode(String.self, forKey: .internationalPrefix)
-        nationalPrefixTransformRule = try? container.decode(String.self, forKey: .nationalPrefixTransformRule)
-        preferredExtnPrefix = try? container.decode(String.self, forKey: .preferredExtnPrefix)
-        emergency = try? container.decode(MetadataPhoneNumberDesc.self, forKey: .emergency)
-        fixedLine = try? container.decode(MetadataPhoneNumberDesc.self, forKey: .fixedLine)
-        generalDesc = try? container.decode(MetadataPhoneNumberDesc.self, forKey: .generalDesc)
-        mobile = try? container.decode(MetadataPhoneNumberDesc.self, forKey: .mobile)
-        pager = try? container.decode(MetadataPhoneNumberDesc.self, forKey: .pager)
-        personalNumber = try? container.decode(MetadataPhoneNumberDesc.self, forKey: .personalNumber)
-        premiumRate = try? container.decode(MetadataPhoneNumberDesc.self, forKey: .premiumRate)
-        sharedCost = try? container.decode(MetadataPhoneNumberDesc.self, forKey: .sharedCost)
-        tollFree = try? container.decode(MetadataPhoneNumberDesc.self, forKey: .tollFree)
-        voicemail = try? container.decode(MetadataPhoneNumberDesc.self, forKey: .voicemail)
-        voip = try? container.decode(MetadataPhoneNumberDesc.self, forKey: .voip)
-        uan = try? container.decode(MetadataPhoneNumberDesc.self, forKey: .uan)
-        leadingDigits = try? container.decode(String.self, forKey: .leadingDigits)
+        internationalPrefix = try container.decodeIfPresent(String.self, forKey: .internationalPrefix)
+        nationalPrefixTransformRule = try container.decodeIfPresent(String.self, forKey: .nationalPrefixTransformRule)
+        preferredExtnPrefix = try container.decodeIfPresent(String.self, forKey: .preferredExtnPrefix)
+        emergency = try container.decodeIfPresent(MetadataPhoneNumberDesc.self, forKey: .emergency)
+        fixedLine = try container.decodeIfPresent(MetadataPhoneNumberDesc.self, forKey: .fixedLine)
+        generalDesc = try container.decodeIfPresent(MetadataPhoneNumberDesc.self, forKey: .generalDesc)
+        mobile = try container.decodeIfPresent(MetadataPhoneNumberDesc.self, forKey: .mobile)
+        pager = try container.decodeIfPresent(MetadataPhoneNumberDesc.self, forKey: .pager)
+        personalNumber = try container.decodeIfPresent(MetadataPhoneNumberDesc.self, forKey: .personalNumber)
+        premiumRate = try container.decodeIfPresent(MetadataPhoneNumberDesc.self, forKey: .premiumRate)
+        sharedCost = try container.decodeIfPresent(MetadataPhoneNumberDesc.self, forKey: .sharedCost)
+        tollFree = try container.decodeIfPresent(MetadataPhoneNumberDesc.self, forKey: .tollFree)
+        voicemail = try container.decodeIfPresent(MetadataPhoneNumberDesc.self, forKey: .voicemail)
+        voip = try container.decodeIfPresent(MetadataPhoneNumberDesc.self, forKey: .voip)
+        uan = try container.decodeIfPresent(MetadataPhoneNumberDesc.self, forKey: .uan)
+        leadingDigits = try container.decodeIfPresent(String.self, forKey: .leadingDigits)
     }
 }
 
@@ -96,11 +96,11 @@ public extension MetadataPhoneNumberFormat {
         nationalPrefixOptionalWhenFormatting = container.decodeBoolString(forKey: .nationalPrefixOptionalWhenFormatting)
 
         // Default parsing logic
-        pattern = try? container.decode(String.self, forKey: .pattern)
-        format = try? container.decode(String.self, forKey: .format)
-        intlFormat = try? container.decode(String.self, forKey: .intlFormat)
-        nationalPrefixFormattingRule = try? container.decode(String.self, forKey: .nationalPrefixFormattingRule)
-        domesticCarrierCodeFormattingRule = try? container.decode(String.self, forKey: .domesticCarrierCodeFormattingRule)
+        pattern = try container.decodeIfPresent(String.self, forKey: .pattern)
+        format = try container.decodeIfPresent(String.self, forKey: .format)
+        intlFormat = try container.decodeIfPresent(String.self, forKey: .intlFormat)
+        nationalPrefixFormattingRule = try container.decodeIfPresent(String.self, forKey: .nationalPrefixFormattingRule)
+        domesticCarrierCodeFormattingRule = try container.decodeIfPresent(String.self, forKey: .domesticCarrierCodeFormattingRule)
     }
 }
 


### PR DESCRIPTION
Using `try?` unnecessarily triggers  swift errors when the value is missing.