### PR TITLE
fix autocomplete phone issue

### DIFF
--- a/PhoneNumberKit/UI/PhoneNumberTextField.swift
+++ b/PhoneNumberKit/UI/PhoneNumberTextField.swift
@@ -395,7 +395,7 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
 
     open func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         // This allows for the case when a user autocompletes a phone number:
-        if range == NSRange(location: 0, length: 0), string == " " {
+        if range == NSRange(location: 0, length: 0), string == "" {
             return true
         }
 


### PR DESCRIPTION
checked on ios 14.2 - when user clicks on phone number suggestion then phone number is not filled in to text field. 

string that is passed to 
open func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String)
is "" - empty string and not " "

thank you