### PR TITLE
Linux support

### DIFF
--- a/PhoneNumberKit/NSRegularExpression+Swift.swift
+++ b/PhoneNumberKit/NSRegularExpression+Swift.swift
@@ -28,12 +28,22 @@ extension String {
 }
 
 extension NSRegularExpression {
+    #if canImport(ObjectiveC)
     func enumerateMatches(in string: String, options: NSRegularExpression.MatchingOptions = [], range: Range<String.Index>? = nil, using block: (NSTextCheckingResult?, NSRegularExpression.MatchingFlags, UnsafeMutablePointer<ObjCBool>) -> Swift.Void) {
         let range = range ?? string.startIndex..<string.endIndex
         let nsRange = string.nsRange(from: range)
 
         self.enumerateMatches(in: string, options: options, range: nsRange, using: block)
     }
+    #else
+    // FIX: block needs to be @escaping
+    func enumerateMatches(in string: String, options: NSRegularExpression.MatchingOptions = [], range: Range<String.Index>? = nil, using block: @escaping (NSTextCheckingResult?, NSRegularExpression.MatchingFlags, UnsafeMutablePointer<ObjCBool>) -> Swift.Void) {
+        let range = range ?? string.startIndex..<string.endIndex
+        let nsRange = string.nsRange(from: range)
+
+        self.enumerateMatches(in: string, options: options, range: nsRange, using: block)
+    }
+    #endif
 
     func matches(in string: String, options: NSRegularExpression.MatchingOptions = [], range: Range<String.Index>? = nil) -> [NSTextCheckingResult] {
         let range = range ?? string.startIndex..<string.endIndex

--- a/PhoneNumberKit/PartialFormatter.swift
+++ b/PhoneNumberKit/PartialFormatter.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2020 Roy Marmelstein. All rights reserved.
 //
 
+#if canImport(ObjectiveC)
 import Foundation
 
 /// Partial formatter
@@ -396,3 +397,4 @@ public final class PartialFormatter {
         return rebuiltString
     }
 }
+#endif

--- a/PhoneNumberKit/PhoneNumberFormatter.swift
+++ b/PhoneNumberKit/PhoneNumberFormatter.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2019 Xenonium. All rights reserved.
 //
 
+#if canImport(ObjectiveC)
 import Foundation
 
 open class PhoneNumberFormatter: Foundation.Formatter {
@@ -219,3 +220,4 @@ private extension unichar {
         return self >= 0x30 && self <= 0x39 // '0' < '9'
     }
 }
+#endif

--- a/PhoneNumberKit/PhoneNumberParser.swift
+++ b/PhoneNumberKit/PhoneNumberParser.swift
@@ -267,7 +267,12 @@ final class PhoneNumberParser {
         guard let possibleNationalPrefix = metadata.nationalPrefixForParsing else {
             return
         }
+        #if canImport(ObjectiveC)
         let prefixPattern = String(format: "^(?:%@)", possibleNationalPrefix)
+        #else
+        // FIX: String format with %@ doesn't work without ObjectiveC (e.g. Linux)
+        let prefixPattern = "^(?:\(possibleNationalPrefix))"
+        #endif
         do {
             let matches = try regex.regexMatches(prefixPattern, string: number)
             if let firstMatch = matches.first {

--- a/PhoneNumberKitTests/PartialFormatterTests.swift
+++ b/PhoneNumberKitTests/PartialFormatterTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2016 Roy Marmelstein. All rights reserved.
 //
 
+#if canImport(ObjectiveC)
 @testable import PhoneNumberKit
 import XCTest
 
@@ -595,3 +596,4 @@ class PartialFormatterTests: XCTestCase {
     }
     
 }
+#endif


### PR DESCRIPTION
This will allow us to use PhoneNumberKit on the server.

Only minimal changes:
- Disabled PartialFormatter and PhoneNumberFormatter on Linux.
- Replaced String(format:) with equivalent function on Linux.

All tests passed `swift test --enable-test-discovery`.

Fixes: https://github.com/marmelroy/PhoneNumberKit/issues/216