### PR TITLE
Implement init overrides

### DIFF
--- a/PhoneNumberKit/PhoneNumberFormatter.swift
+++ b/PhoneNumberKit/PhoneNumberFormatter.swift
@@ -46,7 +46,7 @@ open class PhoneNumberFormatter: Foundation.Formatter {
         super.init()
     }
 
-    public override init() {
+    @objc public override dynamic init() {
         self.phoneNumberKit = PhoneNumberKit()
         self.partialFormatter = PartialFormatter(phoneNumberKit: self.phoneNumberKit, defaultRegion: PhoneNumberKit.defaultRegionCode(), withPrefix: true)
         super.init()

--- a/PhoneNumberKit/PhoneNumberFormatter.swift
+++ b/PhoneNumberKit/PhoneNumberFormatter.swift
@@ -46,6 +46,12 @@ open class PhoneNumberFormatter: Foundation.Formatter {
         super.init()
     }
 
+    public override init() {
+        self.phoneNumberKit = PhoneNumberKit()
+        self.partialFormatter = PartialFormatter(phoneNumberKit: self.phoneNumberKit, defaultRegion: PhoneNumberKit.defaultRegionCode(), withPrefix: true)
+        super.init()
+    }
+
     public required init?(coder aDecoder: NSCoder) {
         self.phoneNumberKit = PhoneNumberKit()
         self.partialFormatter = PartialFormatter(phoneNumberKit: self.phoneNumberKit, defaultRegion: self.defaultRegion, withPrefix: self.withPrefix)

--- a/PhoneNumberKit/PhoneNumberKit.swift
+++ b/PhoneNumberKit/PhoneNumberKit.swift
@@ -27,7 +27,7 @@ public final class PhoneNumberKit: NSObject {
         super.init()
     }
 
-    public override init() {
+    @objc public override dynamic init() {
         let metadataCallback = PhoneNumberKit.defaultMetadataCallback
         self.metadataManager = MetadataManager(metadataCallback: metadataCallback)
         self.parseManager = ParseManager(metadataManager: self.metadataManager, regexManager: self.regexManager)

--- a/PhoneNumberKit/PhoneNumberKit.swift
+++ b/PhoneNumberKit/PhoneNumberKit.swift
@@ -21,9 +21,17 @@ public final class PhoneNumberKit: NSObject {
 
     // MARK: Lifecycle
 
-    public init(metadataCallback: @escaping MetadataCallback = PhoneNumberKit.defaultMetadataCallback) {
+    public init(metadataCallback: @escaping MetadataCallback) {
         self.metadataManager = MetadataManager(metadataCallback: metadataCallback)
         self.parseManager = ParseManager(metadataManager: self.metadataManager, regexManager: self.regexManager)
+        super.init()
+    }
+
+    public override init() {
+        let metadataCallback = PhoneNumberKit.defaultMetadataCallback
+        self.metadataManager = MetadataManager(metadataCallback: metadataCallback)
+        self.parseManager = ParseManager(metadataManager: self.metadataManager, regexManager: self.regexManager)
+        super.init()
     }
 
     // MARK: Parsing


### PR DESCRIPTION
If you compile this pod with module stability flag - you will this in swiftinterface file:
```
@objc final public class PhoneNumberKit : ObjectiveC.NSObject {
  public init(metadataCallback: @escaping PhoneNumberKitFramework.MetadataCallback = PhoneNumberKit.defaultMetadataCallback)
  ...
  @objc override dynamic public init()
  @objc deinit
}
```

By default, objc subclasses, which marked as `@objc` suppose to have override init method. Xcode 12.5 decided to use that declared init, rather than declared in swift and non-objc one with empty parameters. Which resulted in error 
```
`use of unimplemented initializer 'init()' for class 'PhoneNumberKit.PhoneNumberKit'`
```

I checked interface and found 2 classes which has this `@objc override dynamic public init()` and for both of them implemented it.

I also have removed 1 default parameter, because there is init without parameter for `PhoneNumberKit`.