### PR TITLE
Replace `class` keyword with `AnyObject`

### DIFF
--- a/PhoneNumberKit/UI/CountryCodePickerViewController.swift
+++ b/PhoneNumberKit/UI/CountryCodePickerViewController.swift
@@ -4,7 +4,7 @@
 import UIKit
 
 @available(iOS 11.0, *)
-public protocol CountryCodePickerDelegate: class {
+public protocol CountryCodePickerDelegate: AnyObject {
     func countryCodePickerViewControllerDidPickCountry(_ country: CountryCodePickerViewController.Country)
 }
 


### PR DESCRIPTION
`class` is deprecated in favor of `AnyObject` for protocol inheritance.