### PR TITLE
Only change default region if the withFlag is true

### DIFF
--- a/PhoneNumberKit/UI/PhoneNumberTextField.swift
+++ b/PhoneNumberKit/UI/PhoneNumberTextField.swift
@@ -438,10 +438,14 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
         }
 
         // we change the default region to be the one most recently typed
-        self._defaultRegion = self.currentRegion
-        self.partialFormatter.defaultRegion = self.currentRegion
-        self.updateFlag()
-        self.updatePlaceholder()
+        // but only when the withFlag is true as to not confuse the user who don't see the flag
+        if withFlag == true
+        {
+            self._defaultRegion = self.currentRegion
+            self.partialFormatter.defaultRegion = self.currentRegion
+            self.updateFlag()
+            self.updatePlaceholder()
+        }
 
         return false
     }


### PR DESCRIPTION
Currently the default region is always set to the region of the last entered phone number.
This behaviour can be confusing if the withFlag flag is set to false as the user won't have an indication that the default region has changed. Leaving the user confused as to why a second ago the text field understood a US number and now it is not because in between he entered a french number.
When the flag are displayed , there is a clear indication of why.

Should address: https://github.com/marmelroy/PhoneNumberKit/issues/316