### PR TITLE
Change the `MetadataPossibleLengths` struct elements access modifier …

### DIFF
--- a/PhoneNumberKit/MetadataTypes.swift
+++ b/PhoneNumberKit/MetadataTypes.swift
@@ -73,8 +73,8 @@ public struct MetadataPhoneNumberDesc: Decodable {
 }
 
 public struct MetadataPossibleLengths: Decodable {
-    let national: String?
-    let localOnly: String?
+    public let national: String?
+    public let localOnly: String?
 }
 
 /**


### PR DESCRIPTION
Change the `MetadataPossibleLengths` struct elements access modifier to `public`. Due to the missing modifier this metadata was unavailable from the `MetadataTerritory`.