### PR TITLE
Fix the bug that NSRange may cross the boundary

### DIFF
--- a/PhoneNumberKit/PhoneNumberParser.swift
+++ b/PhoneNumberKit/PhoneNumberParser.swift
@@ -97,10 +97,7 @@ final class PhoneNumberParser {
             }
             startPosition = 1
         }
-        for i in 1...numberLength {
-            if i > maxCountryCode {
-                break
-            }
+        for i in 1...min(numberLength - startPosition, maxCountryCode) {
             let stringRange = NSRange(location: startPosition, length: i)
             let subNumber = nsFullNumber.substring(with: stringRange)
             if let potentialCountryCode = UInt64(subNumber), metadata.territoriesByCode[potentialCountryCode] != nil {

--- a/PhoneNumberKit/RegexManager.swift
+++ b/PhoneNumberKit/RegexManager.swift
@@ -128,27 +128,7 @@ final class RegexManager {
 
     // MARK: String and replace
 
-    func replaceStringByRegex(_ pattern: String, string: String) -> String {
-        do {
-            var replacementResult = string
-            let regex = try regexWithPattern(pattern)
-            let matches = regex.matches(in: string)
-            if matches.count == 1 {
-                let range = regex.rangeOfFirstMatch(in: string)
-                if range != nil {
-                    replacementResult = regex.stringByReplacingMatches(in: string, options: [], range: range, withTemplate: "")
-                }
-                return replacementResult
-            } else if matches.count > 1 {
-                replacementResult = regex.stringByReplacingMatches(in: string, withTemplate: "")
-            }
-            return replacementResult
-        } catch {
-            return string
-        }
-    }
-
-    func replaceStringByRegex(_ pattern: String, string: String, template: String) -> String {
+    func replaceStringByRegex(_ pattern: String, string: String, template: String = "") -> String {
         do {
             var replacementResult = string
             let regex = try regexWithPattern(pattern)

--- a/PhoneNumberKit/UI/CountryCodePickerViewController.swift
+++ b/PhoneNumberKit/UI/CountryCodePickerViewController.swift
@@ -25,7 +25,7 @@ public class CountryCodePickerViewController: UITableViewController {
     lazy var allCountries = phoneNumberKit
         .allCountries()
         .compactMap({ Country(for: $0, with: self.phoneNumberKit) })
-        .sorted(by: { $0.name.caseInsensitiveCompare($1.name) == .orderedAscending })
+        .sorted(by: { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending })
 
     lazy var countries: [[Country]] = {
         let countries = allCountries

--- a/PhoneNumberKit/UI/PhoneNumberTextField.swift
+++ b/PhoneNumberKit/UI/PhoneNumberTextField.swift
@@ -219,7 +219,6 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
      */
     public convenience init(withPhoneNumberKit phoneNumberKit: PhoneNumberKit) {
         self.init(frame: .zero, phoneNumberKit: phoneNumberKit)
-        self.setup()
     }
 
     /**


### PR DESCRIPTION
1. Remove the duplicate method `replaceStringByRegex`.

2. Fix the bug that NSRange may cross the boundary

3. When working with text that’s presented to the user, use the localizedCaseInsensitiveCompare(_:) method instead.

4. Remove duplicate calls `setup`.
