### PR TITLE
Update the Regex of National number prefix patterns

### DIFF
--- a/PhoneNumberKit/Constants.swift
+++ b/PhoneNumberKit/Constants.swift
@@ -137,7 +137,7 @@ struct PhoneNumberPatterns {
 
     static let standaloneDigitPattern = "\\d(?=[^,}][^,}])"
 
-    static let nationalPrefixParsingPattern = "^(?:%@)"
+    static let nationalPrefixParsingPattern = "^/d(?:%@)"
 
     static let prefixSeparatorPattern = "[- ]"
 


### PR DESCRIPTION
Fix The Issue #453
Issue observed that if "withPrefix" is disable and "withFlag" and "withDefaultPickerUI" is enable then the user cant able to enter the national prefix number. If the starting phone number is the same as the national prefix then also it was not working.

Hence update the "nationalPrefixParsingPattern" regex in "Constants.swift" file