### PR TITLE
remove nil value from carrier cellular provider

### DIFF
--- a/PhoneNumberKit/PhoneNumberKit.swift
+++ b/PhoneNumberKit/PhoneNumberKit.swift
@@ -298,7 +298,7 @@ public final class PhoneNumberKit: NSObject {
         let networkInfo = CTTelephonyNetworkInfo()
         var carrier: CTCarrier? = nil
         if #available(iOS 12.0, *) {
-            carrier = networkInfo.serviceSubscriberCellularProviders?.values.first
+            carrier = networkInfo.serviceSubscriberCellularProviders?.values.compactMap({ $0 }).first
         } else {
             carrier = networkInfo.subscriberCellularProvider
         }


### PR DESCRIPTION
since the values come from dictionary, the order is not guaranteed and may contain nil object. Using a compact map to remove nil object from the array. Maybe the array should be strongly ordered (alphabetically?) to provide some consistency. 