### PR TITLE
Fix bundle accessor for SwiftUI previews.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,8 +17,7 @@ let package = Package(
                 exclude: ["Resources/Original",
                           "Resources/README.md",
                           "Resources/update.sh",
-                          "Info.plist", 
-                          "Bundle+Resources.swift"],
+                          "Info.plist"],
                 resources: [
                     .process("Resources/PhoneNumberMetadata.json")
                 ]),

--- a/PhoneNumberKit/Bundle+Resources.swift
+++ b/PhoneNumberKit/Bundle+Resources.swift
@@ -1,10 +1,31 @@
-
 import Foundation
 
-// This extension is required as part of supporting resources in SPM.
-// It's included in all other buid products.
+private class CurrentBundleFinder {}
+
+// The custom bundle locator code is needed to work around a bug in Xcode
+// where SwiftUI previews in an SPM module will crash if they try to use
+// resources in another SPM module that are loaded using the synthesized
+// Bundle.module accessor.
+//
 extension Bundle {
-    static var module: Bundle = {
-        Bundle(for: PhoneNumberKit.self)
+    static var phoneNumberKit: Bundle = {
+        let bundleName = "PhoneNumberKit_PhoneNumberKit"
+        let candidates = [
+            /* Bundle should be present here when the package is linked into an App. */
+            Bundle.main.resourceURL,
+            /* Bundle should be present here when the package is linked into a framework. */
+            Bundle(for: CurrentBundleFinder.self).resourceURL,
+            /* For command-line tools. */
+            Bundle.main.bundleURL,
+            /* Bundle should be present here when running previews from a different package (this is the path to "…/Debug-iphonesimulator/"). */
+            Bundle(for: CurrentBundleFinder.self).resourceURL?.deletingLastPathComponent().deletingLastPathComponent()
+        ]
+        for candidate in candidates {
+            let bundlePath = candidate?.appendingPathComponent(bundleName + ".bundle")
+            if let bundle = bundlePath.flatMap(Bundle.init(url:)) {
+                return bundle
+            }
+        }
+        fatalError("Could not find bundle \(bundleName), tried candidates: \(candidates)!")
     }()
 }

--- a/PhoneNumberKit/PhoneNumberKit.swift
+++ b/PhoneNumberKit/PhoneNumberKit.swift
@@ -322,7 +322,7 @@ public final class PhoneNumberKit: NSObject {
     ///
     /// - returns: an optional Data representation of the metadata.
     public static func defaultMetadataCallback() throws -> Data? {
-        let frameworkBundle = Bundle.module
+        let frameworkBundle = Bundle.phoneNumberKit
         guard let jsonPath = frameworkBundle.path(forResource: "PhoneNumberMetadata", ofType: "json") else {
             throw PhoneNumberError.metadataNotFound
         }


### PR DESCRIPTION
There is a [bug in Xcode (still present as of 13.2 beta)](https://forums.swift.org/t/swiftui-previewer-crashes-while-in-swift-package-that-depends-on-anothers-packages-bundle-module-reference/41736) that causes SwiftUI previews to crash when:

a) Your preview is in an SPM module.
b) The view in question uses resources from another imported SPM module.

We use SPM pretty heavily in our app and so are familiar with this issue. I've just been updating our PhoneNumberKit dependency from 2.5.1 to 3.3.3 and am now facing this issue with PhoneNumberKit - we have a view components library that has some SwiftUI view components, one of which uses PhoneNumberKit. The SwiftUI previews now crash because PhoneNumberKit now uses SPM resources to load the JSON metadata.

There is fortunately a workaround - its a bit ugly but we've been using this workaround successfully in our own SPM modules for some time. The trick is to define a custom bundle accessor that checks the correct path for SwiftUI previews, rather than using the compiler-synthesised `Bundle.module`, which does not search the correct paths that Xcode expects when compiling and rendering SwiftUI previews.

This is what Xcode generates when building:

```swift
private class BundleFinder {}

extension Foundation.Bundle {
    /// Returns the resource bundle associated with the current Swift module.
    static var module: Bundle = {
        let bundleName = "PhoneNumberKit_PhoneNumberKit"

        let candidates = [
            // Bundle should be present here when the package is linked into an App.
            Bundle.main.resourceURL,

            // Bundle should be present here when the package is linked into a framework.
            Bundle(for: BundleFinder.self).resourceURL,

            // For command-line tools.
            Bundle.main.bundleURL,
        ]

        for candidate in candidates {
            let bundlePath = candidate?.appendingPathComponent(bundleName + ".bundle")
            if let bundle = bundlePath.flatMap(Bundle.init(url:)) {
                return bundle
            }
        }
        fatalError("unable to find bundle named PhoneNumberKit_PhoneNumberKit")
    }()
}
```

Note the additional line used here, which is what finds the bundle for SwiftUI previews:

```swift
Bundle(for: CurrentBundleFinder.self).resourceURL?.deletingLastPathComponent().deletingLastPathComponent()
```