### PR TITLE
🔗 Callable URL and call() method to call on a device

### DIFF
--- a/PhoneNumberKit/PhoneNumber.swift
+++ b/PhoneNumberKit/PhoneNumber.swift
@@ -58,6 +58,14 @@ extension PhoneNumber {
     public func notParsed() -> Bool {
         return self.type == .notParsed
     }
+    
+    /**
+     Get a callable URL from the number.
+     - Returns: A callable URL.
+     */
+    public var url: URL? {
+        return URL(string: "tel://" + numberString)
+    }
 }
 
 /// In past versions of PhoneNumberKit you were able to initialize a PhoneNumber object to parse a String. Please use a PhoneNumberKit object's methods.
@@ -84,3 +92,31 @@ public extension PhoneNumber {
         throw PhoneNumberError.deprecated
     }
 }
+
+#if os(iOS)
+import UIKit
+
+public extension PhoneNumber {
+    
+    /**
+     Calls the phone number.
+     */
+    func call() {
+        guard let url = url else { return }
+        UIApplication.shared.openURL(url)
+    }
+}
+#elseif os(macOS)
+import AppKit
+
+public extension PhoneNumber {
+    
+    /**
+     Calls the phone number.
+     */
+    func call() {
+        guard let url = url else { return }
+        NSWorkspace.shared.open(url)
+    }
+}
+#endif


### PR DESCRIPTION
This PR adds a calling feature to the `PhoneNumber` struct.

A callable URL of the format `tel://<number>` is returned from the `url` computer property. If used within iOS or macOS, the `call()` method can be used to open the `url`, calling the number.