### PR TITLE
Fix Swift 5.6 crash on Linux

### DIFF
--- a/PhoneNumberKit/RegexManager.swift
+++ b/PhoneNumberKit/RegexManager.swift
@@ -11,9 +11,9 @@ import Foundation
 final class RegexManager {
 
     public init() {
-        let characterSet = NSMutableCharacterSet(charactersIn: "\u{00a0}")
-        characterSet.formUnion(with: CharacterSet.whitespacesAndNewlines)
-        self.spaceCharacterSet = characterSet as CharacterSet
+        var characterSet = CharacterSet(charactersIn: "\u{00a0}")
+        characterSet.formUnion(.whitespacesAndNewlines)
+        self.spaceCharacterSet = characterSet
     }
 
     // MARK: Regular expression pool

--- a/PhoneNumberKit/RegexManager.swift
+++ b/PhoneNumberKit/RegexManager.swift
@@ -11,7 +11,7 @@ import Foundation
 final class RegexManager {
 
     public init() {
-        var characterSet = CharacterSet(charactersIn: "\u{00a0}")
+        var characterSet = CharacterSet(charactersIn: PhoneNumberConstants.nonBreakingSpace)
         characterSet.formUnion(.whitespacesAndNewlines)
         self.spaceCharacterSet = characterSet
     }

--- a/PhoneNumberKit/UI/PhoneNumberTextField.swift
+++ b/PhoneNumberKit/UI/PhoneNumberTextField.swift
@@ -146,12 +146,12 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
         withPrefix: withPrefix
     )
 
-    let nonNumericSet: NSCharacterSet = {
-        var mutableSet = NSMutableCharacterSet.decimalDigit().inverted
+    let nonNumericSet: CharacterSet = {
+        var mutableSet = CharacterSet.decimalDigits.inverted
         mutableSet.remove(charactersIn: PhoneNumberConstants.plusChars)
         mutableSet.remove(charactersIn: PhoneNumberConstants.pausesAndWaitsChars)
         mutableSet.remove(charactersIn: PhoneNumberConstants.operatorChars)
-        return mutableSet as NSCharacterSet
+        return mutableSet
     }()
 
     private weak var _delegate: UITextFieldDelegate?
@@ -357,7 +357,7 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
         for i in cursorEnd..<textAsNSString.length {
             let cursorRange = NSRange(location: i, length: 1)
             let candidateNumberAfterCursor: NSString = textAsNSString.substring(with: cursorRange) as NSString
-            if candidateNumberAfterCursor.rangeOfCharacter(from: self.nonNumericSet as CharacterSet).location == NSNotFound {
+            if candidateNumberAfterCursor.rangeOfCharacter(from: self.nonNumericSet).location == NSNotFound {
                 for j in cursorRange.location..<textAsNSString.length {
                     let candidateCharacter = textAsNSString.substring(with: NSRange(location: j, length: 1))
                     if candidateCharacter == candidateNumberAfterCursor as String {
@@ -415,14 +415,14 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
         let modifiedTextField = textAsNSString.replacingCharacters(in: range, with: string)
 
         let filteredCharacters = modifiedTextField.filter {
-            String($0).rangeOfCharacter(from: (textField as! PhoneNumberTextField).nonNumericSet as CharacterSet) == nil
+            String($0).rangeOfCharacter(from: (textField as! PhoneNumberTextField).nonNumericSet) == nil
         }
         let rawNumberString = String(filteredCharacters)
 
         let formattedNationalNumber = self.partialFormatter.formatPartial(rawNumberString as String)
         var selectedTextRange: NSRange?
 
-        let nonNumericRange = (changedRange.rangeOfCharacter(from: self.nonNumericSet as CharacterSet).location != NSNotFound)
+        let nonNumericRange = (changedRange.rangeOfCharacter(from: self.nonNumericSet).location != NSNotFound)
         if range.length == 1, string.isEmpty, nonNumericRange {
             selectedTextRange = self.selectionRangeForNumberReplacement(textField: textField, formattedText: modifiedTextField)
             textField.text = modifiedTextField


### PR DESCRIPTION
## Problem

The following exception occurs on Linux with the newly introduced Swift 5.6:

```
$ docker run --rm -v "$PWD:$PWD" -w "$PWD" swift:5.6-focal bash -c 'swift test'

Building for debugging...
[1/8] Copying PhoneNumberMetadata.json
[2/22] Emitting module PhoneNumberKit
[3/25] Compiling PhoneNumberKit PartialFormatter.swift
[4/25] Compiling PhoneNumberKit PhoneNumber.swift
[5/25] Compiling PhoneNumberKit PhoneNumberFormatter.swift
[6/25] Compiling PhoneNumberKit CountryCodePickerViewController.swift
[7/25] Compiling PhoneNumberKit PhoneNumberTextField.swift
[8/25] Compiling PhoneNumberKit resource_bundle_accessor.swift
[9/25] Compiling PhoneNumberKit PhoneNumberKit.swift
[10/25] Compiling PhoneNumberKit PhoneNumberParser.swift
[11/25] Compiling PhoneNumberKit RegexManager.swift
[12/25] Compiling PhoneNumberKit MetadataTypes.swift
[13/25] Compiling PhoneNumberKit NSRegularExpression+Swift.swift
[14/25] Compiling PhoneNumberKit ParseManager.swift
[15/25] Compiling PhoneNumberKit Constants.swift
[16/25] Compiling PhoneNumberKit Formatter.swift
[17/25] Compiling PhoneNumberKit MetadataManager.swift
[18/25] Compiling PhoneNumberKit MetadataParsing.swift
[21/27] Wrapping AST for PhoneNumberKit for debugging
[22/32] Linking libPhoneNumberKit-Dynamic.so
[23/32] Compiling PhoneNumberKitTests PhoneNumberTextFieldTests.swift
[24/32] Archiving libPhoneNumberKit-Static.a
[25/32] Compiling PhoneNumberKitTests PhoneNumberKitTests.swift
[26/32] Compiling PhoneNumberKitTests PartialFormatterTests.swift
[27/32] Compiling PhoneNumberKitTests PhoneNumberKitParsingTests.swift
[28/32] Emitting module PhoneNumberKitTests
[31/34] /Users/davdroman/Developer/davdroman/PhoneNumberKit/.build/aarch64-unknown-linux-gnu/debug/PhoneNumberKitPackageTests.derived/runner.swift
[32/34] Wrapping AST for PhoneNumberKitTests for debugging
[33/37] Compiling PhoneNumberKitPackageTests runner.swift
[34/37] Emitting module PhoneNumberKitPackageTests
[35/37] Compiling PhoneNumberKitPackageTests PhoneNumberKitTests.swift
[38/39] Wrapping AST for PhoneNumberKitPackageTests for debugging
[39/39] Linking PhoneNumberKitPackageTests.xctest
Build complete! (12.53s)
2022-03-27 14:29:00.867 PhoneNumberKitPackageTests.xctest[312:96b9f010] void CFCharacterSetUnion(CFMutableCharacterSetRef, CFCharacterSetRef): Immutable character set passed to mutable function
error: Exited with signal code 5
```

## Solution

The log hints at the issue with the fragment `void CFCharacterSetUnion(CFMutableCharacterSetRef, CFCharacterSetRef): Immutable character set passed to mutable function`.

Upon inspection, I was able to determine the crash occurs in `RegexManager.swift:14` because that's the only one point where a character set is mutated when linking against Linux.

The solution consists of dropping `NSMutableCharacterSet` and using `CharacterSet` directly instead.

The *reason* for this being the solution is unclear to me, but I suspect it has to do with how CoreFoundation interoperates with swift-corelibs-foundation vs Apple Foundation.

---

I also took the liberty to replace every other use of `NSMutableCharacterSet` with the seemingly safer `CharacterSet` counterpart as well in `PhoneNumberTextField.swift`, even though it won't affect Linux in any way.