### PR TITLE
Introduce coding strategies

### DIFF
--- a/PhoneNumberKit.xcodeproj/project.pbxproj
+++ b/PhoneNumberKit.xcodeproj/project.pbxproj
@@ -81,6 +81,11 @@
 		C6DF6CDF1D1B18D800259F4B /* PhoneNumberParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 342418811BB70F5200EE70E7 /* PhoneNumberParser.swift */; };
 		C6DF6CE01D1B18D800259F4B /* RegexManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34566C991BC112C500715E6B /* RegexManager.swift */; };
 		C9D81F822348025700B75AB7 /* PhoneNumberTextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D81F812348025700B75AB7 /* PhoneNumberTextFieldTests.swift */; };
+		D51A60A9274416050021EE7E /* PhoneNumber+Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51A60A8274416050021EE7E /* PhoneNumber+Codable.swift */; };
+		D51A60AA2744160B0021EE7E /* PhoneNumber+Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51A60A8274416050021EE7E /* PhoneNumber+Codable.swift */; };
+		D51A60AB2744160B0021EE7E /* PhoneNumber+Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51A60A8274416050021EE7E /* PhoneNumber+Codable.swift */; };
+		D51A60AC2744160C0021EE7E /* PhoneNumber+Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51A60A8274416050021EE7E /* PhoneNumber+Codable.swift */; };
+		D51A60AE27442EF50021EE7E /* PhoneNumber+CodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51A60AD27442EF50021EE7E /* PhoneNumber+CodableTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -126,6 +131,8 @@
 		C6DF6CA71D1B145300259F4B /* PhoneNumberKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PhoneNumberKit.h; sourceTree = "<group>"; };
 		C6DF6CCC1D1B18B000259F4B /* PhoneNumberKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PhoneNumberKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C9D81F812348025700B75AB7 /* PhoneNumberTextFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneNumberTextFieldTests.swift; sourceTree = "<group>"; };
+		D51A60A8274416050021EE7E /* PhoneNumber+Codable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PhoneNumber+Codable.swift"; sourceTree = "<group>"; };
+		D51A60AD27442EF50021EE7E /* PhoneNumber+CodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PhoneNumber+CodableTests.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -222,6 +229,7 @@
 				34566C991BC112C500715E6B /* RegexManager.swift */,
 				34F26FBD2517DCB700B6AF4D /* Bundle+Resources.swift */,
 				3424187F1BB705B500EE70E7 /* PhoneNumber.swift */,
+				D51A60A8274416050021EE7E /* PhoneNumber+Codable.swift */,
 				34AA66011BDD160B00467912 /* Constants.swift */,
 				3420CF5D1BE8959F00FAE34F /* Formatter.swift */,
 				343B850A1C62A25600918E46 /* PartialFormatter.swift */,
@@ -240,6 +248,7 @@
 			isa = PBXGroup;
 			children = (
 				342418731BB6E5A000EE70E7 /* PhoneNumberKitTests.swift */,
+				D51A60AD27442EF50021EE7E /* PhoneNumber+CodableTests.swift */,
 				346EF14D1C69C688008C7306 /* PartialFormatterTests.swift */,
 				34776AA71BE2BF1100400790 /* PhoneNumberKitParsingTests.swift */,
 				342418751BB6E5A000EE70E7 /* Info.plist */,
@@ -496,6 +505,7 @@
 				3417BD6B2210AC4900477EE7 /* MetadataParsing.swift in Sources */,
 				346922691BC023A60023482F /* PhoneNumberKit.swift in Sources */,
 				343B850C1C62A25600918E46 /* PartialFormatter.swift in Sources */,
+				D51A60A9274416050021EE7E /* PhoneNumber+Codable.swift in Sources */,
 				3422D9BA1BE6A2D500867D02 /* ParseManager.swift in Sources */,
 				34566C9A1BC112C500715E6B /* RegexManager.swift in Sources */,
 				342418801BB705B500EE70E7 /* PhoneNumber.swift in Sources */,
@@ -509,6 +519,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D51A60AE27442EF50021EE7E /* PhoneNumber+CodableTests.swift in Sources */,
 				34776AA81BE2BF1100400790 /* PhoneNumberKitParsingTests.swift in Sources */,
 				342418741BB6E5A000EE70E7 /* PhoneNumberKitTests.swift in Sources */,
 				346EF14E1C69C688008C7306 /* PartialFormatterTests.swift in Sources */,
@@ -529,6 +540,7 @@
 				1B80904E2300B4DC006AE849 /* MetadataParsing.swift in Sources */,
 				C6DF6C5C1D1B09DD00259F4B /* PhoneNumber.swift in Sources */,
 				C6DF6C541D1B09DD00259F4B /* Constants.swift in Sources */,
+				D51A60AA2744160B0021EE7E /* PhoneNumber+Codable.swift in Sources */,
 				34F26FBF2517DCB700B6AF4D /* Bundle+Resources.swift in Sources */,
 				C6DF6C591D1B09DD00259F4B /* MetadataTypes.swift in Sources */,
 				C6DF6C5F1D1B09DD00259F4B /* RegexManager.swift in Sources */,
@@ -550,6 +562,7 @@
 				1B80904F2300B4DC006AE849 /* MetadataParsing.swift in Sources */,
 				C6DF6CBA1D1B159A00259F4B /* PhoneNumber.swift in Sources */,
 				C6DF6CB21D1B159A00259F4B /* Constants.swift in Sources */,
+				D51A60AB2744160B0021EE7E /* PhoneNumber+Codable.swift in Sources */,
 				34F26FC02517DCB700B6AF4D /* Bundle+Resources.swift in Sources */,
 				C6DF6CB71D1B159A00259F4B /* MetadataTypes.swift in Sources */,
 				C6DF6CBD1D1B159A00259F4B /* RegexManager.swift in Sources */,
@@ -571,6 +584,7 @@
 				C6DF6CD51D1B18D800259F4B /* Constants.swift in Sources */,
 				1B8090502300B4DD006AE849 /* MetadataParsing.swift in Sources */,
 				C6DF6CDA1D1B18D800259F4B /* MetadataTypes.swift in Sources */,
+				D51A60AC2744160C0021EE7E /* PhoneNumber+Codable.swift in Sources */,
 				34F26FC12517DCB700B6AF4D /* Bundle+Resources.swift in Sources */,
 				C6DF6CE01D1B18D800259F4B /* RegexManager.swift in Sources */,
 				C6DF6CD91D1B18D800259F4B /* MetadataManager.swift in Sources */,

--- a/PhoneNumberKit/PhoneNumber+Codable.swift
+++ b/PhoneNumberKit/PhoneNumber+Codable.swift
@@ -1,0 +1,144 @@
+//
+//  PhoneNumber+Codable.swift
+//  PhoneNumberKit
+//
+//  Created by David Roman on 16/11/2021.
+//  Copyright © 2021 Roy Marmelstein. All rights reserved.
+//
+
+import Foundation
+
+/// The strategy used to decode a `PhoneNumber` value.
+public enum PhoneNumberDecodingStrategy {
+    /// Decode `PhoneNumber` properties as key-value pairs. This is the default strategy.
+    case properties
+    /// Decode `PhoneNumber` as a E164 formatted string.
+    case e164
+    /// The default `PhoneNumber` encoding strategy.
+    public static var `default` = properties
+}
+
+/// The strategy used to encode a `PhoneNumber` value.
+public enum PhoneNumberEncodingStrategy {
+    /// Encode `PhoneNumber` properties as key-value pairs. This is the default strategy.
+    case properties
+    /// Encode `PhoneNumber` as a E164 formatted string.
+    case e164
+    /// The default `PhoneNumber` encoding strategy.
+    public static var `default` = properties
+}
+
+public enum PhoneNumberDecodingUtils {
+    /// The default `PhoneNumberKit` instance used for parsing when decoding, if needed.
+    public static var defaultPhoneNumberKit: () -> PhoneNumberKit = { .init() }
+}
+
+public enum PhoneNumberEncodingUtils {
+    /// The default `PhoneNumberKit` instance used for formatting when encoding, if needed.
+    public static var defaultPhoneNumberKit: () -> PhoneNumberKit = { .init() }
+}
+
+extension JSONDecoder {
+    /// The strategy used to decode a `PhoneNumber` value.
+    public var phoneNumberDecodingStrategy: PhoneNumberDecodingStrategy {
+        get {
+            return userInfo[.phoneNumberDecodingStrategy] as? PhoneNumberDecodingStrategy ?? .default
+        }
+        set {
+            userInfo[.phoneNumberDecodingStrategy] = newValue
+        }
+    }
+
+    /// The `PhoneNumberKit` instance used for parsing when decoding, if needed.
+    public var phoneNumberKit: () -> PhoneNumberKit {
+        get {
+            return userInfo[.phoneNumberKit] as? () -> PhoneNumberKit ?? PhoneNumberDecodingUtils.defaultPhoneNumberKit
+        }
+        set {
+            userInfo[.phoneNumberKit] = newValue
+        }
+    }
+}
+
+extension JSONEncoder {
+    /// The strategy used to encode a `PhoneNumber` value.
+    public var phoneNumberEncodingStrategy: PhoneNumberEncodingStrategy {
+        get {
+            return userInfo[.phoneNumberEncodingStrategy] as? PhoneNumberEncodingStrategy ?? .default
+        }
+        set {
+            userInfo[.phoneNumberEncodingStrategy] = newValue
+        }
+    }
+
+    /// The `PhoneNumberKit` instance used for formatting when encoding, if needed.
+    public var phoneNumberKit: () -> PhoneNumberKit {
+        get {
+            return userInfo[.phoneNumberKit] as? () -> PhoneNumberKit ?? PhoneNumberEncodingUtils.defaultPhoneNumberKit
+        }
+        set {
+            userInfo[.phoneNumberKit] = newValue
+        }
+    }
+}
+
+extension PhoneNumber: Codable {
+    public init(from decoder: Decoder) throws {
+        let strategy = decoder.userInfo[.phoneNumberDecodingStrategy] as? PhoneNumberDecodingStrategy ?? .default
+        switch strategy {
+        case .properties:
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            try self.init(
+                numberString: container.decode(String.self, forKey: .numberString),
+                countryCode: container.decode(UInt64.self, forKey: .countryCode),
+                leadingZero: container.decode(Bool.self, forKey: .leadingZero),
+                nationalNumber: container.decode(UInt64.self, forKey: .nationalNumber),
+                numberExtension: container.decodeIfPresent(String.self, forKey: .numberExtension),
+                type: container.decode(PhoneNumberType.self, forKey: .type),
+                regionID: container.decodeIfPresent(String.self, forKey: .regionID)
+            )
+        case .e164:
+            let container = try decoder.singleValueContainer()
+            let e164String = try container.decode(String.self)
+            let phoneNumberKit = decoder.userInfo[.phoneNumberKit] as? () -> PhoneNumberKit ?? PhoneNumberDecodingUtils.defaultPhoneNumberKit
+            self = try phoneNumberKit().parse(e164String, ignoreType: true)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        let strategy = encoder.userInfo[.phoneNumberEncodingStrategy] as? PhoneNumberEncodingStrategy ?? .default
+        switch strategy {
+        case .properties:
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(numberString, forKey: .numberString)
+            try container.encode(countryCode, forKey: .countryCode)
+            try container.encode(leadingZero, forKey: .leadingZero)
+            try container.encode(nationalNumber, forKey: .nationalNumber)
+            try container.encode(numberExtension, forKey: .numberExtension)
+            try container.encode(type, forKey: .type)
+            try container.encode(regionID, forKey: .regionID)
+        case .e164:
+            var container = encoder.singleValueContainer()
+            let phoneNumberKit = encoder.userInfo[.phoneNumberKit] as? () -> PhoneNumberKit ?? PhoneNumberEncodingUtils.defaultPhoneNumberKit
+            let e164String = phoneNumberKit().format(self, toType: .e164)
+            try container.encode(e164String)
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case numberString
+        case countryCode
+        case leadingZero
+        case nationalNumber
+        case numberExtension
+        case type
+        case regionID
+    }
+}
+
+extension CodingUserInfoKey {
+    static let phoneNumberDecodingStrategy = Self(rawValue: "com.roymarmelstein.PhoneNumberKit.decoding-strategy")!
+    static let phoneNumberEncodingStrategy = Self(rawValue: "com.roymarmelstein.PhoneNumberKit.encoding-strategy")!
+
+    static let phoneNumberKit = Self(rawValue: "com.roymarmelstein.PhoneNumberKit.instance")!
+}

--- a/PhoneNumberKit/PhoneNumber.swift
+++ b/PhoneNumberKit/PhoneNumber.swift
@@ -18,7 +18,7 @@ import Foundation
  - numberExtension: Extension if available. String. Optional
  - type: Computed phone number type on access. Returns from an enumeration - PNPhoneNumberType.
  */
-public struct PhoneNumber: Codable {
+public struct PhoneNumber {
     public let numberString: String
     public let countryCode: UInt64
     public let leadingZero: Bool

--- a/PhoneNumberKitTests/PhoneNumber+CodableTests.swift
+++ b/PhoneNumberKitTests/PhoneNumber+CodableTests.swift
@@ -1,0 +1,261 @@
+//
+//  PhoneNumber+CodableTests.swift
+//  PhoneNumberKitTests
+//
+//  Created by David Roman on 16/11/2021.
+//  Copyright © 2021 Roy Marmelstein. All rights reserved.
+//
+
+import PhoneNumberKit
+import XCTest
+
+final class PhoneNumberCodableTests: XCTestCase {
+    let phoneNumberKit = PhoneNumberKit()
+}
+
+extension PhoneNumberCodableTests {
+    func testDecode_defaultStrategy() throws {
+        try assertDecode(
+            """
+            {
+              "countryCode" : 44,
+              "leadingZero" : false,
+              "nationalNumber" : 1632960015,
+              "numberExtension" : null,
+              "numberString" : "+441632960015",
+              "regionID" : "GB",
+              "type" : "unknown"
+            }
+            """,
+            phoneNumberKit.parse("+441632960015", ignoreType: true),
+            strategy: nil
+        )
+        try assertDecode(
+            """
+            {
+              "countryCode" : 34,
+              "leadingZero" : false,
+              "nationalNumber" : 646990213,
+              "numberExtension" : null,
+              "numberString" : "+34646990213",
+              "regionID" : "ES",
+              "type" : "unknown"
+            }
+            """,
+            phoneNumberKit.parse("+34646990213", ignoreType: true),
+            strategy: nil
+        )
+    }
+
+    func testDecode_propertiesStrategy() throws {
+        try assertDecode(
+            """
+            {
+              "countryCode" : 44,
+              "leadingZero" : false,
+              "nationalNumber" : 1632960015,
+              "numberExtension" : null,
+              "numberString" : "+441632960015",
+              "regionID" : "GB",
+              "type" : "unknown"
+            }
+            """,
+            phoneNumberKit.parse("+441632960015", ignoreType: true),
+            strategy: .properties
+        )
+        try assertDecode(
+            """
+            {
+              "countryCode" : 34,
+              "leadingZero" : false,
+              "nationalNumber" : 646990213,
+              "numberExtension" : null,
+              "numberString" : "+34646990213",
+              "regionID" : "ES",
+              "type" : "unknown"
+            }
+            """,
+            phoneNumberKit.parse("+34646990213", ignoreType: true),
+            strategy: .properties
+        )
+    }
+
+    func testDecode_e164Strategy() throws {
+        try assertDecode(
+            """
+            "+441632960015"
+            """,
+            phoneNumberKit.parse("+441632960015", ignoreType: true),
+            strategy: .e164
+        )
+        try assertDecode(
+            """
+            "+441632960015"
+            """,
+            phoneNumberKit.parse("01632960015", withRegion: "GB", ignoreType: true),
+            strategy: .e164
+        )
+        try assertDecode(
+            """
+            "+34646990213"
+            """,
+            phoneNumberKit.parse("+34646990213", ignoreType: true),
+            strategy: .e164
+        )
+        try assertDecode(
+            """
+            "+34646990213"
+            """,
+            phoneNumberKit.parse("646990213", withRegion: "ES", ignoreType: true),
+            strategy: .e164
+        )
+    }
+}
+
+extension PhoneNumberCodableTests {
+    func testEncode_defaultStrategy() throws {
+        try assertEncode(
+            phoneNumberKit.parse("+441632960015", ignoreType: true),
+            """
+            {
+              "countryCode" : 44,
+              "leadingZero" : false,
+              "nationalNumber" : 1632960015,
+              "numberExtension" : null,
+              "numberString" : "+441632960015",
+              "regionID" : "GB",
+              "type" : "unknown"
+            }
+            """,
+            strategy: nil
+        )
+        try assertEncode(
+            phoneNumberKit.parse("+34646990213", ignoreType: true),
+            """
+            {
+              "countryCode" : 34,
+              "leadingZero" : false,
+              "nationalNumber" : 646990213,
+              "numberExtension" : null,
+              "numberString" : "+34646990213",
+              "regionID" : "ES",
+              "type" : "unknown"
+            }
+            """,
+            strategy: nil
+        )
+    }
+
+    func testEncode_propertiesStrategy() throws {
+        try assertEncode(
+            phoneNumberKit.parse("+441632960015", ignoreType: true),
+            """
+            {
+              "countryCode" : 44,
+              "leadingZero" : false,
+              "nationalNumber" : 1632960015,
+              "numberExtension" : null,
+              "numberString" : "+441632960015",
+              "regionID" : "GB",
+              "type" : "unknown"
+            }
+            """,
+            strategy: .properties
+        )
+        try assertEncode(
+            phoneNumberKit.parse("+34646990213", ignoreType: true),
+            """
+            {
+              "countryCode" : 34,
+              "leadingZero" : false,
+              "nationalNumber" : 646990213,
+              "numberExtension" : null,
+              "numberString" : "+34646990213",
+              "regionID" : "ES",
+              "type" : "unknown"
+            }
+            """,
+            strategy: .properties
+        )
+    }
+
+    func testEncode_e164Strategy() throws {
+        try assertEncode(
+            phoneNumberKit.parse("+441632960015", ignoreType: true),
+            """
+            "+441632960015"
+            """,
+            strategy: .e164
+        )
+        try assertEncode(
+            phoneNumberKit.parse("01632960015", withRegion: "GB", ignoreType: true),
+            """
+            "+441632960015"
+            """,
+            strategy: .e164
+        )
+        try assertEncode(
+            phoneNumberKit.parse("+34646990213", ignoreType: true),
+            """
+            "+34646990213"
+            """,
+            strategy: .e164
+        )
+        try assertEncode(
+            phoneNumberKit.parse("646990213", withRegion: "ES", ignoreType: true),
+            """
+            "+34646990213"
+            """,
+            strategy: .e164
+        )
+    }
+}
+
+private extension PhoneNumberCodableTests {
+    func assertDecode(
+        _ json: String,
+        _ expectedPhoneNumber: PhoneNumber,
+        strategy: PhoneNumberDecodingStrategy?,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws {
+        let decoder = JSONDecoder()
+        if let strategy = strategy {
+            decoder.phoneNumberDecodingStrategy = strategy
+        }
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        let sut = try decoder.decode(PhoneNumber.self, from: data)
+        XCTAssertEqual(sut, expectedPhoneNumber, file: file, line: line)
+    }
+
+    func assertEncode(
+        _ phoneNumber: PhoneNumber,
+        _ expectedJSON: String,
+        strategy: PhoneNumberEncodingStrategy?,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws {
+        let encoder = JSONEncoder()
+        if let strategy = strategy {
+            encoder.phoneNumberEncodingStrategy = strategy
+        }
+        if #available(iOS 11.0, *) {
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            let data = try encoder.encode(phoneNumber)
+            let json = String(decoding: data, as: UTF8.self)
+            XCTAssertEqual(json, expectedJSON, file: file, line: line)
+        } else {
+            let data = try encoder.encode(phoneNumber)
+            let jsonObject = try JSONSerialization.jsonObject(with: data, options: [.allowFragments])
+            switch jsonObject {
+            case let json as String:
+                XCTAssertEqual("\"" + json + "\"", expectedJSON, file: file, line: line)
+            case let json as [String: AnyHashable]:
+                let expectedJSON = try JSONSerialization.jsonObject(with: Data(expectedJSON.utf8)) as? [String: AnyHashable]
+                XCTAssertEqual(json, expectedJSON, file: file, line: line)
+            default:
+                XCTFail("JSON parsing failed", file: file, line: line)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Oftentimes, APIs that deal with phone numbers expect the E164 format. Currently however, `PhoneNumber`'s conformance to `Codable` is compiler-synthesized, so all its properties are encoded as individual fields.

This PR enables E164 encoding/decoding for `PhoneNumber`. This is accomplished by ditching the auto-synthesized `Codable` conformance and implementing encoding/decoding strategies. This is reminiscent of how `DateEncodingStrategy` and `DateDecodingStrategy` work.

In order not to introduce breaking changes, the default strategy is `properties`, which corresponds to the existing behavior. The `e164` strategy is purely opt-in. Nevertheless, in case of a future major version bump, I'd suggest perhaps considering the possibility of E164 as the default strategy instead.