### PR TITLE
Fix bundle search path

### DIFF
--- a/PhoneNumberKit/Bundle+Resources.swift
+++ b/PhoneNumberKit/Bundle+Resources.swift
@@ -19,7 +19,9 @@ extension Bundle {
             /* For command-line tools. */
             Bundle.main.bundleURL,
             /* Bundle should be present here when running previews from a different package (this is the path to "…/Debug-iphonesimulator/"). */
-            Bundle(for: CurrentBundleFinder.self).resourceURL?.deletingLastPathComponent().deletingLastPathComponent()
+            Bundle(for: CurrentBundleFinder.self).resourceURL?.deletingLastPathComponent().deletingLastPathComponent(),
+            /* Bundle should be present here when running previews from a framework which imports framework whick imports PhoneNumberKit package (this is the path to "…/Debug-iphonesimulator/"). */
+            Bundle(for: CurrentBundleFinder.self).resourceURL?.deletingLastPathComponent()
         ]
         for candidate in candidates {
             let bundlePath = candidate?.appendingPathComponent(bundleName + ".bundle")


### PR DESCRIPTION
When running SwiftUI preview in a framework `Feature` which imports framework `CommonUI` which imports other framework `Core` which imports PhoneNumberKit swift package the bundle search path has to delete only one path component 