### PR TITLE
Simplified default region code discovery

### DIFF
--- a/PhoneNumberKit/PhoneNumberKit.swift
+++ b/PhoneNumberKit/PhoneNumberKit.swift
@@ -7,9 +7,7 @@
 //
 
 import Foundation
-#if os(iOS)
-import CoreTelephony
-#endif
+import Contacts
 
 public typealias MetadataCallback = (() throws -> Data?)
 
@@ -18,10 +16,6 @@ public final class PhoneNumberKit: NSObject {
     let metadataManager: MetadataManager
     let parseManager: ParseManager
     let regexManager = RegexManager()
-
-    #if os(iOS) && !targetEnvironment(simulator) && !targetEnvironment(macCatalyst)
-    private static let networkInfo = CTTelephonyNetworkInfo()
-    #endif
 
     // MARK: Lifecycle
 
@@ -298,28 +292,7 @@ public final class PhoneNumberKit: NSObject {
     ///
     /// - returns: A computed value for the user's current region - based on the iPhone's carrier and if not available, the device region.
     public class func defaultRegionCode() -> String {
-        #if os(iOS) && !targetEnvironment(simulator) && !targetEnvironment(macCatalyst)
-        var carrier: CTCarrier?
-        if #available(iOS 12.0, *) {
-            carrier = networkInfo.serviceSubscriberCellularProviders?.values.compactMap({ $0 }).first
-        } else {
-            carrier = networkInfo.subscriberCellularProvider
-        }
-
-        if let isoCountryCode = carrier?.isoCountryCode {
-            return isoCountryCode.uppercased()
-        }
-        #endif
-
-        let currentLocale = Locale.current
-        if #available(iOS 10.0, *), let countryCode = currentLocale.regionCode {
-            return countryCode.uppercased()
-        } else {
-            if let countryCode = (currentLocale as NSLocale).object(forKey: .countryCode) as? String {
-                return countryCode.uppercased()
-            }
-        }
-        return PhoneNumberConstants.defaultCountry
+        return CNContactsUserDefaults.shared().countryCode
     }
 
     /// Default metadata callback, reads metadata from PhoneNumberMetadata.json file in bundle

--- a/PhoneNumberKitTests/PhoneNumberKitParsingTests.swift
+++ b/PhoneNumberKitTests/PhoneNumberKitParsingTests.swift
@@ -442,6 +442,47 @@ class PhoneNumberKitParsingTests: XCTestCase {
         print("time to parse \(numberOfParses) phone numbers, \(timeInterval) seconds")
         XCTAssertTrue(timeInterval < 5)
     }
+    
+    func testPerformanceNonOptimizedSimple() {
+        let numberOfParses = 2000
+        let startTime = Date()
+        var endTime = Date()
+        for _ in 0..<numberOfParses {
+            _ = try? self.phoneNumberKit.parse("+5491187654321", ignoreType: true)
+        }
+        endTime = Date()
+        let timeInterval = endTime.timeIntervalSince(startTime)
+        print("time to parse \(numberOfParses) phone numbers, \(timeInterval) seconds")
+        XCTAssertTrue(timeInterval < 1)
+    }
+    
+    func testPerformanceWithoutSupplyingDefaultRegion() {
+        let numberOfParses = 2000
+        let startTime = Date()
+        var endTime = Date()
+        var numberArray: [String] = []
+        for _ in 0..<numberOfParses {
+            numberArray.append("+5491187654321")
+        }
+        _ = self.phoneNumberKit.parse(numberArray, ignoreType: true)
+        endTime = Date()
+        let timeInterval = endTime.timeIntervalSince(startTime)
+        print("time to parse \(numberOfParses) phone numbers, \(timeInterval) seconds")
+        XCTAssertTrue(timeInterval < 1)
+    }
+    
+    func testPerformanceNonOptimizedParsingUsageWithoutDefaultRegion() {
+        let numberOfParses = 2000
+        let startTime = Date()
+        var endTime = Date()
+        for _ in 0..<numberOfParses {
+            _ = try? self.phoneNumberKit.parse("+5491187654321", ignoreType: true)
+        }
+        endTime = Date()
+        let timeInterval = endTime.timeIntervalSince(startTime)
+        print("time to parse \(numberOfParses) phone numbers, \(timeInterval) seconds")
+        XCTAssertTrue(timeInterval < 1)
+    }
 
     func testMultipleMutated() {
         let numberOfParses = 500


### PR DESCRIPTION
Simplified `defaultRegionCode()` in `PhoneNumberKit` in order to handle better the multiple SIM related issues.

- The `CoreTelephony` based solution was replaced with a `Contacts` framework based one.
- Added more strict performance tests for parsing both via an array,. and through a non-optimized way (calling the `parse(_:_:)` method in the body of a for loop).

I wrote about the multi-SIM and the country region code discovery issues here: https://petermolnar.dev/core-telephony-based-location-your-dual-sim-iphone-is-not-fully-supported/

@bguidolim , please review and merge if you think it is feasible. 