### PR TITLE
Fixed unknown default region

### DIFF
--- a/PhoneNumberKit/PartialFormatter.swift
+++ b/PhoneNumberKit/PartialFormatter.swift
@@ -42,7 +42,7 @@ public final class PartialFormatter {
 
     func updateMetadataForDefaultRegion() {
         guard let metadataManager = metadataManager else { return }
-        if let regionMetadata = metadataManager.territoriesByCountry[defaultRegion] {
+        if let regionMetadata = metadataManager.territoriesByCountry[defaultRegion.uppercased()] {
             self.defaultMetadata = metadataManager.mainTerritory(forCode: regionMetadata.countryCode)
         } else {
             self.defaultMetadata = nil


### PR DESCRIPTION
Default region returned from `CNContactsUserDefaults.shared().countryCode` is lowercased while `metadataManager.territoriesByCountry` dictionary keys are all uppercased.

This means the current version always use the `US` as default fallback metadata.