### PR TITLE
Show correct flag with same prefix according to the region code

### DIFF
--- a/PhoneNumberKit/UI/PhoneNumberTextField.swift
+++ b/PhoneNumberKit/UI/PhoneNumberTextField.swift
@@ -515,6 +515,17 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
             self.updatePlaceholder()
         }
     }
+    
+    public func setPhoneNumber(phone: String) {
+        text = phone
+        guard let phoneNumber = self.phoneNumber else { return }
+        guard let regionCode = phoneNumberKit.getRegionCode(of: phoneNumber) else { return }
+        _defaultRegion = regionCode
+        partialFormatter.defaultRegion = regionCode
+        updateFlag()
+        updatePlaceholder()
+    }
+    
 }
 
 @available(iOS 11.0, *)


### PR DESCRIPTION
Given that the region code value is unique for each country. Therefore, the region code can be used to display the flag correctly for every country whose country code is the same.
For example, Canada and the United States both have the same country code(+1), but different region codes (CA, US)