### PR TITLE
Fix #451 no flag change for different regionCode

### DIFF
--- a/PhoneNumberKit/UI/PhoneNumberTextField.swift
+++ b/PhoneNumberKit/UI/PhoneNumberTextField.swift
@@ -277,6 +277,11 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
 
     open func updateFlag() {
         guard self.withFlag else { return }
+        if let phoneNumber = phoneNumber, let regionCode = phoneNumberKit.getRegionCode(of: phoneNumber) {
+            _defaultRegion = regionCode
+            partialFormatter.defaultRegion = regionCode
+        }
+
         let flagBase = UnicodeScalar("🇦").value - UnicodeScalar("A").value
 
         let flag = self.currentRegion

--- a/PhoneNumberKitTests/PhoneNumberTextFieldTests.swift
+++ b/PhoneNumberKitTests/PhoneNumberTextFieldTests.swift
@@ -40,6 +40,27 @@ class PhoneNumberTextFieldTests: XCTestCase {
 		tf.text = ""
 		XCTAssertNil(tf.phoneNumber)
 	}
+
+
+    func testUSPhoneNumberWithFlag() {
+        let pnk = PhoneNumberKit()
+        let tf = PhoneNumberTextField(withPhoneNumberKit: pnk)
+        tf.partialFormatter.defaultRegion = "US"
+        tf.withFlag = true
+        tf.text = "4125551212"
+        XCTAssertNotNil(tf.flagButton)
+        XCTAssertEqual(tf.flagButton.titleLabel?.text, "🇺🇸 ")
+    }
+
+    func testNonUSPhoneNumberWithFlag() {
+        let pnk = PhoneNumberKit()
+        let tf = PhoneNumberTextField(withPhoneNumberKit: pnk)
+        tf.partialFormatter.defaultRegion = "US"
+        tf.withFlag = true
+        tf.text = "5872170177"
+        XCTAssertNotNil(tf.flagButton)
+        XCTAssertEqual(tf.flagButton.titleLabel?.text, "🇨🇦 ")
+    }
 }
 
 #endif


### PR DESCRIPTION
**Summary**
Some countries share [region code](https://en.wikipedia.org/wiki/List_of_country_calling_codes) (like +1 for Canada and USA) but have a different area code. 

We need to update the flag with the correct flag in these cases.

**What's inside**
Fix + tests.

**Additionally**
Works automatically with the current `PhoneNumberTextField`.