### PR TITLE
Introducing the new error `ambiguousNumber`

### DIFF
--- a/PhoneNumberKit/Constants.swift
+++ b/PhoneNumberKit/Constants.swift
@@ -39,6 +39,7 @@ public enum PhoneNumberError: Error {
     case tooShort
     case deprecated
     case metadataNotFound
+    case ambiguousNumber(phoneNumbers: [PhoneNumber])
 }
 
 extension PhoneNumberError: LocalizedError {
@@ -52,6 +53,7 @@ extension PhoneNumberError: LocalizedError {
         case .tooShort: return NSLocalizedString("The number provided is too short.", comment: "")
         case .deprecated: return NSLocalizedString("This function is deprecated.", comment: "")
         case .metadataNotFound: return NSLocalizedString("Valid metadata is missing.", comment: "")
+        case .ambiguousNumber: return NSLocalizedString("Phone number is ambiguous.", comment: "")
         }
     }
 }

--- a/PhoneNumberKit/ParseManager.swift
+++ b/PhoneNumberKit/ParseManager.swift
@@ -75,15 +75,20 @@ final class ParseManager {
         }
 
         // If everything fails, iterate through other territories with the same country code (7)
+        var possibleResults = [PhoneNumber]()
         if let metadataList = metadataManager.filterTerritories(byCode: countryCode) {
             for metadata in metadataList where regionMetadata.codeID != metadata.codeID {
                 if let result = try validPhoneNumber(from: nationalNumber, using: metadata, countryCode: countryCode, ignoreType: ignoreType, numberString: numberString, numberExtension: numberExtension) {
-                    return result
+                    possibleResults.append(result)
                 }
             }
         }
-            
-        throw PhoneNumberError.notANumber
+        
+        switch possibleResults.count {
+        case 0: throw PhoneNumberError.notANumber
+        case 1: return possibleResults[0]
+        default: throw PhoneNumberError.ambiguousNumber(phoneNumbers: possibleResults)
+        }
     }
 
     // Parse task


### PR DESCRIPTION
ParseManager now throws an error with a list of possible phone numbers in case a number was not able to be parsed and the guessing logic provides multiple phone numbers.

This PR fixes #445 