### PR TITLE
ensure default country code is capitalized 

### DIFF
--- a/PhoneNumberKit/PhoneNumberKit.swift
+++ b/PhoneNumberKit/PhoneNumberKit.swift
@@ -299,10 +299,10 @@ public final class PhoneNumberKit: NSObject {
             // macCatalyst OS bug if language is set to Korean
             //CNContactsUserDefaults.shared().countryCode will return ko instead of kr
             // Failed parsing any phone number.
-            let countryCode = CNContactsUserDefaults.shared().countryCode
+            let countryCode = CNContactsUserDefaults.shared().countryCode.uppercased()
             #if targetEnvironment(macCatalyst)
                 if "ko".caseInsensitiveCompare(countryCode) == .orderedSame {
-                    return "kr"
+                    return "KR"
                 }
             #endif
             return countryCode
@@ -316,6 +316,8 @@ public final class PhoneNumberKit: NSObject {
         }
         return PhoneNumberConstants.defaultCountry
     }
+    
+    
 
     /// Default metadata callback, reads metadata from PhoneNumberMetadata.json file in bundle
     ///


### PR DESCRIPTION
Ensure defaultRegionCode() always returns capitalized country codes, as it did before this was broken by https://github.com/marmelroy/PhoneNumberKit/pull/538

updating from 3.3.1 to current version broke this in my app.

admittedly , i probably shouldn't have assumed a third party library was meeting iso specifications and called .uppercased() on the result myself, but this is an easy fix overall.  