### PR TITLE
Xcode 14.3 Data(contentsOfFile:) crash fixed with NSData bridging

### DIFF
--- a/PhoneNumberKit/PhoneNumberKit.swift
+++ b/PhoneNumberKit/PhoneNumberKit.swift
@@ -327,8 +327,14 @@ public final class PhoneNumberKit: NSObject {
         guard let jsonPath = frameworkBundle.path(forResource: "PhoneNumberMetadata", ofType: "json") else {
             throw PhoneNumberError.metadataNotFound
         }
-        let data = try Data(contentsOf: URL(fileURLWithPath: jsonPath))
-        return data
+//        let data = try Data(contentsOf: URL(fileURLWithPath: jsonPath))
+//        return data
+        if let nsData = NSData(contentsOfFile: jsonPath) {
+            let data = Data(referencing: nsData)
+            return data
+        } else {
+            throw PhoneNumberError.metadataNotFound
+        }
     }
 }
 


### PR DESCRIPTION
Xcode 14.3 bug with `Data(contentsOfFile:)` crash (#613) fixed with `Data(referencing: NSData(contentsOfFile:))` bridging

