### PR TITLE
Fix ambiguous phone number detection

### DIFF
--- a/PhoneNumberKit/Constants.swift
+++ b/PhoneNumberKit/Constants.swift
@@ -40,7 +40,7 @@ public enum PhoneNumberError: Error, Equatable {
     case tooShort
     case deprecated
     case metadataNotFound
-    case ambiguousNumber(phoneNumbers: [PhoneNumber])
+    case ambiguousNumber(phoneNumbers: Set<PhoneNumber>)
 }
 
 extension PhoneNumberError: LocalizedError {

--- a/PhoneNumberKit/ParseManager.swift
+++ b/PhoneNumberKit/ParseManager.swift
@@ -75,18 +75,18 @@ final class ParseManager {
         }
 
         // If everything fails, iterate through other territories with the same country code (7)
-        var possibleResults = [PhoneNumber]()
+        var possibleResults: Set<PhoneNumber> = []
         if let metadataList = metadataManager.filterTerritories(byCode: countryCode) {
             for metadata in metadataList where regionMetadata.codeID != metadata.codeID {
                 if let result = try validPhoneNumber(from: nationalNumber, using: metadata, countryCode: countryCode, ignoreType: ignoreType, numberString: numberString, numberExtension: numberExtension) {
-                    possibleResults.append(result)
+                    possibleResults.insert(result)
                 }
             }
         }
         
         switch possibleResults.count {
         case 0: throw PhoneNumberError.notANumber
-        case 1: return possibleResults[0]
+        case 1: return possibleResults.first!
         default: throw PhoneNumberError.ambiguousNumber(phoneNumbers: possibleResults)
         }
     }

--- a/PhoneNumberKitTests/PhoneNumberKitParsingTests.swift
+++ b/PhoneNumberKitTests/PhoneNumberKitParsingTests.swift
@@ -547,4 +547,10 @@ class PhoneNumberKitParsingTests: XCTestCase {
         XCTAssertEqual(number.type, PhoneNumberType.mobile)
         XCTAssertEqual(number.numberExtension, "22")
     }
+
+    func testNonAmbiguousPhoneNumber() {
+        // This phone number was incorrectly identified as ambiguous.
+        let address = "+1 345 916 1234"
+        try XCTAssertNotNil(phoneNumberKit.parse(address, withRegion: "JM"))
+    }
 }


### PR DESCRIPTION
`possibleResults` could end up with multiple instances of identical phone numbers leading to an incorrect `ambiguousNumber` error.