### PR TITLE
Enhancement: Added Insets Support for PhoneNumberTextField

### DIFF
--- a/PhoneNumberKit/UI/PhoneNumberTextField.swift
+++ b/PhoneNumberKit/UI/PhoneNumberTextField.swift
@@ -210,6 +210,10 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
         }
         super.layoutSubviews()
     }
+    
+    // MARK: - Insets
+    private var insets: UIEdgeInsets?
+    private var clearButtonPadding: CGFloat?
 
     // MARK: Lifecycle
 
@@ -249,6 +253,30 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
     public override init(frame: CGRect) {
         self.phoneNumberKit = PhoneNumberKit()
         super.init(frame: frame)
+        self.setup()
+    }
+    
+   
+    /**
+     Initialize an instance with specific insets and clear button padding.
+
+     This initializer creates an instance of the class with custom UIEdgeInsets and padding for the clear button.
+     Both of these parameters are used to customize the appearance of the text field and its clear button within the class.
+     
+     - Parameters:
+       - insets: The UIEdgeInsets to be applied to the text field's bounding rectangle. These insets define the padding
+         that is applied within the text field's bounding rectangle. A UIEdgeInsets value contains insets for
+         each of the four directions (top, bottom, left, right). Positive values move the content toward the center of the
+         text field, and negative values move the content toward the edges of the text field.
+       - clearButtonPadding: The padding to be applied to the clear button. This value defines the space between the clear
+         button and the edges of the text field. A positive value increases the distance between the clear button and the
+         text field's edges, and a negative value decreases this distance.
+    */
+    public init(insets: UIEdgeInsets, clearButtonPadding: CGFloat) {
+        self.phoneNumberKit = PhoneNumberKit()
+        self.insets = insets
+        self.clearButtonPadding = clearButtonPadding
+        super.init(frame: .zero)
         self.setup()
     }
 
@@ -553,6 +581,38 @@ extension PhoneNumberTextField: CountryCodePickerDelegate {
         }
     }
 }
+
+// MARK: - Insets
+
+extension PhoneNumberTextField {
+    
+    open override func textRect(forBounds bounds: CGRect) -> CGRect {
+        if let insets = self.insets {
+            return super.textRect(forBounds: bounds.inset(by: insets))
+        } else {
+            return super.textRect(forBounds: bounds)
+        }
+    }
+    
+    open override func editingRect(forBounds bounds: CGRect) -> CGRect {
+        if let insets = self.insets {
+            return super.editingRect(forBounds: bounds
+                .inset(by: insets))
+        } else {
+            return super.editingRect(forBounds: bounds)
+        }
+    }
+    
+    open override func clearButtonRect(forBounds bounds: CGRect) -> CGRect {
+        if let insets = self.insets,
+           let clearButtonPadding = self.clearButtonPadding {
+            return super.clearButtonRect(forBounds: bounds.insetBy(dx: insets.left - clearButtonPadding, dy: 0))
+        } else {
+            return clearButtonRect(forBounds: bounds)
+        }
+    }
+}
+
 
 extension String {
   var isBlank: Bool {


### PR DESCRIPTION
I've developed an enhancement to the PhoneNumberTextField. This new feature brings support for UIEdgeInsets and clear button padding that allows developers to modify the visual appearance of the text field more flexibly.

**Details of the Changes:**

1. I've introduced two new optional properties under the `Insets` mark: `insets` and `clearButtonPadding`. These will allow the developer to adjust the insets for the text field's bounding rectangle and the clear button's padding.

2. I've added a new initializer that accepts UIEdgeInsets and clearButtonPadding as parameters. This initializer provides a simple way to create a PhoneNumberTextField instance with custom insets and clear button padding.

3. The above properties have been implemented in the `PhoneNumberTextField` extension:
   - In the `textRect(forBounds:)` and `editingRect(forBounds:)` methods, if `insets` is set, the text field's bounds are inset by the defined UIEdgeInsets. If `insets` is not set, the bounds remain the same.
   - In the `clearButtonRect(forBounds:)` method, if both `insets` and `clearButtonPadding` are set, the bounds for the clear button are adjusted accordingly. If not, the bounds remain the same.

**Benefits of these Changes:**

This enhancement brings a new layer of customization to the PhoneNumberTextField. Developers now have more control over the aesthetics of the PhoneNumberTextField within their apps, allowing for a better alignment with their app's visual design.

I'm looking forward to your feedback on this enhancement. I believe it's a valuable addition to the library, making it more versatile for usage in diverse design contexts.
 Please the sample below & the attached screenshot below: 

### Example
```swift
 let phoneNumberTextField = PhoneNumberTextField(
    insets: UIEdgeInsets(top: 14, left: 16, bottom: 14, right: 16),
    clearButtonPadding: 6
)

// Other custominizations such as adding border etc..
```

### Output:
<img width="216" alt="Paddings" src="https://github.com/marmelroy/PhoneNumberKit/assets/25889447/8219f78a-c589-4cbd-89b3-cb21aa211360">

<img width="210" alt="Screenshot 2023-07-02 at 3 53 10 AM" src="https://github.com/marmelroy/PhoneNumberKit/assets/25889447/6f4a8816-083c-4e60-b2ea-7f310a352f9a">

