### PR TITLE
Improve PhoneNumberKitParsingTests

### DIFF
--- a/PhoneNumberKitTests/PhoneNumberKitParsingTests.swift
+++ b/PhoneNumberKitTests/PhoneNumberKitParsingTests.swift
@@ -11,7 +11,7 @@ import Foundation
 @testable import PhoneNumberKit
 import XCTest
 
-class PhoneNumberKitParsingTests: XCTestCase {
+final class PhoneNumberKitParsingTests: XCTestCase {
     let phoneNumberKit = PhoneNumberKit()
 
     override func setUp() {
@@ -23,173 +23,136 @@ class PhoneNumberKitParsingTests: XCTestCase {
     }
 
     func testFailingNumber() {
-        do {
-            _ = try self.phoneNumberKit.parse("+5491187654321 ABC123", withRegion: "AR")
-            XCTFail()
-        } catch {
-            XCTAssertTrue(true)
+        XCTAssertThrowsError(try self.phoneNumberKit.parse("+5491187654321 ABC123", withRegion: "AR")) { error in
+            XCTAssertEqual(error as? PhoneNumberError, .invalidNumber)
         }
     }
 
-    func testUSNumberNoPrefix() {
-        do {
-            let phoneNumber1 = try phoneNumberKit.parse("650 253 0000", withRegion: "US")
-            XCTAssertNotNil(phoneNumber1)
-            let phoneNumberInternationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .international, withPrefix: false)
-            XCTAssertTrue(phoneNumberInternationalFormat1 == "650-253-0000")
-            let phoneNumberNationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .national, withPrefix: false)
-            XCTAssertTrue(phoneNumberNationalFormat1 == "(650) 253-0000")
-            let phoneNumberE164Format1 = self.phoneNumberKit.format(phoneNumber1, toType: .e164, withPrefix: false)
-            XCTAssertTrue(phoneNumberE164Format1 == "6502530000")
-            let phoneNumber2 = try phoneNumberKit.parse("800 253 0000", withRegion: "US")
-            XCTAssertNotNil(phoneNumber2)
-            let phoneNumberInternationalFormat2 = self.phoneNumberKit.format(phoneNumber2, toType: .international, withPrefix: false)
-            XCTAssertTrue(phoneNumberInternationalFormat2 == "800-253-0000")
-            let phoneNumberNationalFormat2 = self.phoneNumberKit.format(phoneNumber2, toType: .national, withPrefix: false)
-            XCTAssertTrue(phoneNumberNationalFormat2 == "(800) 253-0000")
-            let phoneNumberE164Format2 = self.phoneNumberKit.format(phoneNumber2, toType: .e164, withPrefix: false)
-            XCTAssertTrue(phoneNumberE164Format2 == "8002530000")
-        } catch {
-            XCTFail()
-        }
+    func testUSNumberNoPrefix() throws {
+        let phoneNumber1 = try phoneNumberKit.parse("650 253 0000", withRegion: "US")
+        let phoneNumberInternationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .international, withPrefix: false)
+        XCTAssertEqual(phoneNumberInternationalFormat1, "650-253-0000")
+        let phoneNumberNationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .national, withPrefix: false)
+        XCTAssertEqual(phoneNumberNationalFormat1, "(650) 253-0000")
+        let phoneNumberE164Format1 = self.phoneNumberKit.format(phoneNumber1, toType: .e164, withPrefix: false)
+        XCTAssertEqual(phoneNumberE164Format1, "6502530000")
+
+        let phoneNumber2 = try phoneNumberKit.parse("800 253 0000", withRegion: "US")
+        let phoneNumberInternationalFormat2 = self.phoneNumberKit.format(phoneNumber2, toType: .international, withPrefix: false)
+        XCTAssertEqual(phoneNumberInternationalFormat2, "800-253-0000")
+        let phoneNumberNationalFormat2 = self.phoneNumberKit.format(phoneNumber2, toType: .national, withPrefix: false)
+        XCTAssertEqual(phoneNumberNationalFormat2, "(800) 253-0000")
+        let phoneNumberE164Format2 = self.phoneNumberKit.format(phoneNumber2, toType: .e164, withPrefix: false)
+        XCTAssertEqual(phoneNumberE164Format2, "8002530000")
     }
 
-    func testUSNumber() {
-        do {
-            let phoneNumber1 = try phoneNumberKit.parse("650 253 0000", withRegion: "US")
-            XCTAssertNotNil(phoneNumber1)
-            let phoneNumberInternationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .international)
-            XCTAssertTrue(phoneNumberInternationalFormat1 == "+1 650-253-0000")
-            let phoneNumberNationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .national)
-            XCTAssertTrue(phoneNumberNationalFormat1 == "(650) 253-0000")
-            let phoneNumberE164Format1 = self.phoneNumberKit.format(phoneNumber1, toType: .e164)
-            XCTAssertTrue(phoneNumberE164Format1 == "+16502530000")
-            let phoneNumber2 = try phoneNumberKit.parse("800 253 0000", withRegion: "US")
-            XCTAssertNotNil(phoneNumber2)
-            let phoneNumberInternationalFormat2 = self.phoneNumberKit.format(phoneNumber2, toType: .international)
-            XCTAssertTrue(phoneNumberInternationalFormat2 == "+1 800-253-0000")
-            let phoneNumberNationalFormat2 = self.phoneNumberKit.format(phoneNumber2, toType: .national)
-            XCTAssertTrue(phoneNumberNationalFormat2 == "(800) 253-0000")
-            let phoneNumberE164Format2 = self.phoneNumberKit.format(phoneNumber2, toType: .e164)
-            XCTAssertTrue(phoneNumberE164Format2 == "+18002530000")
-            let phoneNumber3 = try phoneNumberKit.parse("900 253 0000", withRegion: "US")
-            XCTAssertNotNil(phoneNumber3)
-            let phoneNumberInternationalFormat3 = self.phoneNumberKit.format(phoneNumber3, toType: .international)
-            XCTAssertTrue(phoneNumberInternationalFormat3 == "+1 900-253-0000")
-            let phoneNumberNationalFormat3 = self.phoneNumberKit.format(phoneNumber3, toType: .national)
-            XCTAssertTrue(phoneNumberNationalFormat3 == "(900) 253-0000")
-            let phoneNumberE164Format3 = self.phoneNumberKit.format(phoneNumber3, toType: .e164)
-            XCTAssertTrue(phoneNumberE164Format3 == "+19002530000")
-        } catch {
-            XCTFail()
-        }
+    func testUSNumber() throws {
+        let phoneNumber1 = try phoneNumberKit.parse("650 253 0000", withRegion: "US")
+        let phoneNumberInternationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .international)
+        XCTAssertEqual(phoneNumberInternationalFormat1, "+1 650-253-0000")
+        let phoneNumberNationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .national)
+        XCTAssertEqual(phoneNumberNationalFormat1, "(650) 253-0000")
+        let phoneNumberE164Format1 = self.phoneNumberKit.format(phoneNumber1, toType: .e164)
+        XCTAssertEqual(phoneNumberE164Format1, "+16502530000")
+
+        let phoneNumber2 = try phoneNumberKit.parse("800 253 0000", withRegion: "US")
+        let phoneNumberInternationalFormat2 = self.phoneNumberKit.format(phoneNumber2, toType: .international)
+        XCTAssertEqual(phoneNumberInternationalFormat2, "+1 800-253-0000")
+        let phoneNumberNationalFormat2 = self.phoneNumberKit.format(phoneNumber2, toType: .national)
+        XCTAssertEqual(phoneNumberNationalFormat2, "(800) 253-0000")
+        let phoneNumberE164Format2 = self.phoneNumberKit.format(phoneNumber2, toType: .e164)
+        XCTAssertEqual(phoneNumberE164Format2, "+18002530000")
+
+        let phoneNumber3 = try phoneNumberKit.parse("900 253 0000", withRegion: "US")
+        let phoneNumberInternationalFormat3 = self.phoneNumberKit.format(phoneNumber3, toType: .international)
+        XCTAssertEqual(phoneNumberInternationalFormat3, "+1 900-253-0000")
+        let phoneNumberNationalFormat3 = self.phoneNumberKit.format(phoneNumber3, toType: .national)
+        XCTAssertEqual(phoneNumberNationalFormat3, "(900) 253-0000")
+        let phoneNumberE164Format3 = self.phoneNumberKit.format(phoneNumber3, toType: .e164)
+        XCTAssertEqual(phoneNumberE164Format3, "+19002530000")
     }
 
-    func testBSNumber() {
-        do {
-            let phoneNumber1 = try phoneNumberKit.parse("242 365 1234", withRegion: "BS")
-            XCTAssertNotNil(phoneNumber1)
-            let phoneNumberInternationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .international)
-            XCTAssertTrue(phoneNumberInternationalFormat1 == "+1 242-365-1234")
-            let phoneNumberNationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .national)
-            XCTAssertTrue(phoneNumberNationalFormat1 == "(242) 365-1234")
-            let phoneNumberE164Format1 = self.phoneNumberKit.format(phoneNumber1, toType: .e164)
-            XCTAssertTrue(phoneNumberE164Format1 == "+12423651234")
-        } catch {
-            XCTFail()
-        }
+    func testBSNumber() throws {
+        let phoneNumber1 = try phoneNumberKit.parse("242 365 1234", withRegion: "BS")
+        let phoneNumberInternationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .international)
+        XCTAssertEqual(phoneNumberInternationalFormat1, "+1 242-365-1234")
+        let phoneNumberNationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .national)
+        XCTAssertEqual(phoneNumberNationalFormat1, "(242) 365-1234")
+        let phoneNumberE164Format1 = self.phoneNumberKit.format(phoneNumber1, toType: .e164)
+        XCTAssertEqual(phoneNumberE164Format1, "+12423651234")
     }
 
-    func testGBNumber() {
-        do {
-            let phoneNumber1 = try phoneNumberKit.parse("(020) 7031 3000", withRegion: "GB")
-            XCTAssertNotNil(phoneNumber1)
-            let phoneNumberInternationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .international)
-            XCTAssertTrue(phoneNumberInternationalFormat1 == "+44 20 7031 3000")
-            let phoneNumberNationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .national)
-            XCTAssertTrue(phoneNumberNationalFormat1 == "020 7031 3000")
-            let phoneNumberE164Format1 = self.phoneNumberKit.format(phoneNumber1, toType: .e164)
-            XCTAssertTrue(phoneNumberE164Format1 == "+442070313000")
-            let phoneNumber2 = try phoneNumberKit.parse("(07912) 345 678", withRegion: "GB")
-            XCTAssertNotNil(phoneNumber2)
-            let phoneNumberInternationalFormat2 = self.phoneNumberKit.format(phoneNumber2, toType: .international)
-            XCTAssertTrue(phoneNumberInternationalFormat2 == "+44 7912 345678")
-            let phoneNumberNationalFormat2 = self.phoneNumberKit.format(phoneNumber2, toType: .national)
-            XCTAssertTrue(phoneNumberNationalFormat2 == "07912 345678")
-            let phoneNumberE164Format2 = self.phoneNumberKit.format(phoneNumber2, toType: .e164)
-            XCTAssertTrue(phoneNumberE164Format2 == "+447912345678")
-        } catch {
-            XCTFail()
-        }
+    func testGBNumber() throws {
+        let phoneNumber1 = try phoneNumberKit.parse("(020) 7031 3000", withRegion: "GB")
+        let phoneNumberInternationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .international)
+        XCTAssertEqual(phoneNumberInternationalFormat1, "+44 20 7031 3000")
+        let phoneNumberNationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .national)
+        XCTAssertEqual(phoneNumberNationalFormat1, "020 7031 3000")
+        let phoneNumberE164Format1 = self.phoneNumberKit.format(phoneNumber1, toType: .e164)
+        XCTAssertEqual(phoneNumberE164Format1, "+442070313000")
+
+        let phoneNumber2 = try phoneNumberKit.parse("(07912) 345 678", withRegion: "GB")
+        let phoneNumberInternationalFormat2 = self.phoneNumberKit.format(phoneNumber2, toType: .international)
+        XCTAssertEqual(phoneNumberInternationalFormat2, "+44 7912 345678")
+        let phoneNumberNationalFormat2 = self.phoneNumberKit.format(phoneNumber2, toType: .national)
+        XCTAssertEqual(phoneNumberNationalFormat2, "07912 345678")
+        let phoneNumberE164Format2 = self.phoneNumberKit.format(phoneNumber2, toType: .e164)
+        XCTAssertEqual(phoneNumberE164Format2, "+447912345678")
     }
 
-    func testDENumber() {
-        do {
-            let phoneNumber1 = try phoneNumberKit.parse("0291 12345678", withRegion: "DE")
-            XCTAssertNotNil(phoneNumber1)
-            let phoneNumberInternationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .international)
-            XCTAssertTrue(phoneNumberInternationalFormat1 == "+49 291 12345678")
-            let phoneNumberNationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .national)
-            XCTAssertTrue(phoneNumberNationalFormat1 == "0291 12345678")
-            let phoneNumberE164Format1 = self.phoneNumberKit.format(phoneNumber1, toType: .e164)
-            XCTAssertTrue(phoneNumberE164Format1 == "+4929112345678")
-            let phoneNumber2 = try phoneNumberKit.parse("04134 1234", withRegion: "DE")
-            XCTAssertNotNil(phoneNumber2)
-            let phoneNumberInternationalFormat2 = self.phoneNumberKit.format(phoneNumber2, toType: .international)
-            XCTAssertTrue(phoneNumberInternationalFormat2 == "+49 4134 1234")
-            let phoneNumberNationalFormat2 = self.phoneNumberKit.format(phoneNumber2, toType: .national)
-            XCTAssertTrue(phoneNumberNationalFormat2 == "04134 1234")
-            let phoneNumberE164Format2 = self.phoneNumberKit.format(phoneNumber2, toType: .e164)
-            XCTAssertTrue(phoneNumberE164Format2 == "+4941341234")
-            let phoneNumber3 = try phoneNumberKit.parse("+49 8021 2345", withRegion: "DE")
-            XCTAssertNotNil(phoneNumber3)
-            let phoneNumberInternationalFormat3 = self.phoneNumberKit.format(phoneNumber3, toType: .international)
-            XCTAssertTrue(phoneNumberInternationalFormat3 == "+49 8021 2345")
-            let phoneNumberNationalFormat3 = self.phoneNumberKit.format(phoneNumber3, toType: .national)
-            XCTAssertTrue(phoneNumberNationalFormat3 == "08021 2345")
-            let phoneNumberE164Format3 = self.phoneNumberKit.format(phoneNumber3, toType: .e164)
-            XCTAssertTrue(phoneNumberE164Format3 == "+4980212345")
-        } catch {
-            XCTFail()
-        }
+    func testDENumber() throws {
+        let phoneNumber1 = try phoneNumberKit.parse("0291 12345678", withRegion: "DE")
+        let phoneNumberInternationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .international)
+        XCTAssertEqual(phoneNumberInternationalFormat1, "+49 291 12345678")
+        let phoneNumberNationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .national)
+        XCTAssertEqual(phoneNumberNationalFormat1, "0291 12345678")
+        let phoneNumberE164Format1 = self.phoneNumberKit.format(phoneNumber1, toType: .e164)
+        XCTAssertEqual(phoneNumberE164Format1, "+4929112345678")
+
+        let phoneNumber2 = try phoneNumberKit.parse("04134 1234", withRegion: "DE")
+        let phoneNumberInternationalFormat2 = self.phoneNumberKit.format(phoneNumber2, toType: .international)
+        XCTAssertEqual(phoneNumberInternationalFormat2, "+49 4134 1234")
+        let phoneNumberNationalFormat2 = self.phoneNumberKit.format(phoneNumber2, toType: .national)
+        XCTAssertEqual(phoneNumberNationalFormat2, "04134 1234")
+        let phoneNumberE164Format2 = self.phoneNumberKit.format(phoneNumber2, toType: .e164)
+        XCTAssertEqual(phoneNumberE164Format2, "+4941341234")
+
+        let phoneNumber3 = try phoneNumberKit.parse("+49 8021 2345", withRegion: "DE")
+        let phoneNumberInternationalFormat3 = self.phoneNumberKit.format(phoneNumber3, toType: .international)
+        XCTAssertEqual(phoneNumberInternationalFormat3, "+49 8021 2345")
+        let phoneNumberNationalFormat3 = self.phoneNumberKit.format(phoneNumber3, toType: .national)
+        XCTAssertEqual(phoneNumberNationalFormat3, "08021 2345")
+        let phoneNumberE164Format3 = self.phoneNumberKit.format(phoneNumber3, toType: .e164)
+        XCTAssertEqual(phoneNumberE164Format3, "+4980212345")
     }
 
-    func testITNumber() {
-        do {
-            let phoneNumber1 = try phoneNumberKit.parse("02 3661 8300", withRegion: "IT")
-            XCTAssertNotNil(phoneNumber1)
-            let phoneNumberInternationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .international)
-            XCTAssertTrue(phoneNumberInternationalFormat1 == "+39 02 3661 8300")
-            let phoneNumberNationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .national)
-            XCTAssertTrue(phoneNumberNationalFormat1 == "02 3661 8300")
-            let phoneNumberE164Format1 = self.phoneNumberKit.format(phoneNumber1, toType: .e164)
-            XCTAssertTrue(phoneNumberE164Format1 == "+390236618300")
-        } catch {
-            XCTFail()
-        }
+    func testITNumber() throws {
+        let phoneNumber1 = try phoneNumberKit.parse("02 3661 8300", withRegion: "IT")
+        XCTAssertNotNil(phoneNumber1)
+        let phoneNumberInternationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .international)
+        XCTAssertEqual(phoneNumberInternationalFormat1, "+39 02 3661 8300")
+        let phoneNumberNationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .national)
+        XCTAssertEqual(phoneNumberNationalFormat1, "02 3661 8300")
+        let phoneNumberE164Format1 = self.phoneNumberKit.format(phoneNumber1, toType: .e164)
+        XCTAssertEqual(phoneNumberE164Format1, "+390236618300")
     }
 
-    func testAUNumber() {
-        do {
-            let phoneNumber1 = try phoneNumberKit.parse("02 3661 8300", withRegion: "AU")
-            XCTAssertNotNil(phoneNumber1)
-            let phoneNumberInternationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .international)
-            XCTAssertTrue(phoneNumberInternationalFormat1 == "+61 2 3661 8300")
-            let phoneNumberNationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .national)
-            XCTAssertTrue(phoneNumberNationalFormat1 == "(02) 3661 8300")
-            let phoneNumberE164Format1 = self.phoneNumberKit.format(phoneNumber1, toType: .e164)
-            XCTAssertTrue(phoneNumberE164Format1 == "+61236618300")
-            let phoneNumber2 = try phoneNumberKit.parse("+61 1800 123 456", withRegion: "AU")
-            XCTAssertNotNil(phoneNumber2)
-            let phoneNumberInternationalFormat2 = self.phoneNumberKit.format(phoneNumber2, toType: .international)
-            XCTAssertTrue(phoneNumberInternationalFormat2 == "+61 1800 123 456")
-            let phoneNumberNationalFormat2 = self.phoneNumberKit.format(phoneNumber2, toType: .national)
-            XCTAssertTrue(phoneNumberNationalFormat2 == "1800 123 456")
-            let phoneNumberE164Format2 = self.phoneNumberKit.format(phoneNumber2, toType: .e164)
-            XCTAssertTrue(phoneNumberE164Format2 == "+611800123456")
-        } catch {
-            XCTFail()
-        }
+    func testAUNumber() throws {
+        let phoneNumber1 = try phoneNumberKit.parse("02 3661 8300", withRegion: "AU")
+        let phoneNumberInternationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .international)
+        XCTAssertEqual(phoneNumberInternationalFormat1, "+61 2 3661 8300")
+        let phoneNumberNationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .national)
+        XCTAssertEqual(phoneNumberNationalFormat1, "(02) 3661 8300")
+        let phoneNumberE164Format1 = self.phoneNumberKit.format(phoneNumber1, toType: .e164)
+        XCTAssertEqual(phoneNumberE164Format1, "+61236618300")
+
+        let phoneNumber2 = try phoneNumberKit.parse("+61 1800 123 456", withRegion: "AU")
+        let phoneNumberInternationalFormat2 = self.phoneNumberKit.format(phoneNumber2, toType: .international)
+        XCTAssertEqual(phoneNumberInternationalFormat2, "+61 1800 123 456")
+        let phoneNumberNationalFormat2 = self.phoneNumberKit.format(phoneNumber2, toType: .national)
+        XCTAssertEqual(phoneNumberNationalFormat2, "1800 123 456")
+        let phoneNumberE164Format2 = self.phoneNumberKit.format(phoneNumber2, toType: .e164)
+        XCTAssertEqual(phoneNumberE164Format2, "+611800123456")
     }
 
     func testAllExampleNumbers() {
@@ -239,120 +202,80 @@ class PhoneNumberKitParsingTests: XCTestCase {
         XCTAssertFalse(regex.matchesEntirely("8", string: number))
     }
 
-    func testUSTollFreeNumberType() {
-        guard let number = try? phoneNumberKit.parse("8002345678", withRegion: "US") else {
-            XCTFail()
-            return
-        }
-        XCTAssertEqual(number.type, PhoneNumberType.tollFree)
+    func testUSTollFreeNumberType() throws {
+        let number = try phoneNumberKit.parse("8002345678", withRegion: "US")
+        XCTAssertEqual(number.type, .tollFree)
     }
 
-    func testBelizeTollFreeType() {
-        guard let number = try? phoneNumberKit.parse("08001234123", withRegion: "BZ") else {
-            XCTFail()
-            return
-        }
-        XCTAssertEqual(number.type, PhoneNumberType.tollFree)
+    func testBelizeTollFreeType() throws {
+        let number = try phoneNumberKit.parse("08001234123", withRegion: "BZ")
+        XCTAssertEqual(number.type, .tollFree)
     }
 
-    func testItalyFixedLineType() {
-        guard let number = try? phoneNumberKit.parse("0669812345", withRegion: "IT") else {
-            XCTFail()
-            return
-        }
-        XCTAssertEqual(number.type, PhoneNumberType.fixedLine)
+    func testItalyFixedLineType() throws {
+        let number = try phoneNumberKit.parse("0669812345", withRegion: "IT")
+        XCTAssertEqual(number.type, .fixedLine)
     }
 
-    func testMaldivesMobileNumber() {
-        guard let number = try? phoneNumberKit.parse("7812345", withRegion: "MV") else {
-            XCTFail()
-            return
-        }
-        XCTAssertEqual(number.type, PhoneNumberType.mobile)
+    func testMaldivesMobileNumber() throws {
+        let number = try phoneNumberKit.parse("7812345", withRegion: "MV")
+        XCTAssertEqual(number.type, .mobile)
     }
 
-    func testZimbabweVoipType() {
-        guard let number = try? phoneNumberKit.parse("8686123456", withRegion: "ZW") else {
-            XCTFail()
-            return
-        }
-        XCTAssertEqual(number.type, PhoneNumberType.voip)
+    func testZimbabweVoipType() throws {
+        let number = try phoneNumberKit.parse("8686123456", withRegion: "ZW")
+        XCTAssertEqual(number.type, .voip)
     }
 
-    func testAntiguaPagerNumberType() {
-        guard let number = try? phoneNumberKit.parse("12684061234", withRegion: "US") else {
-            XCTFail()
-            return
-        }
-        XCTAssertEqual(number.type, PhoneNumberType.pager)
+    func testAntiguaPagerNumberType() throws {
+        let number = try phoneNumberKit.parse("12684061234", withRegion: "US")
+        XCTAssertEqual(number.type, .pager)
     }
 
-    func testFranceMobileNumberType() {
-        guard let number = try? phoneNumberKit.parse("+33 612-345-678") else {
-            XCTFail()
-            return
-        }
-        XCTAssertEqual(number.type, PhoneNumberType.mobile)
+    func testFranceMobileNumberType() throws {
+        let number = try phoneNumberKit.parse("+33 612-345-678")
+        XCTAssertEqual(number.type, .mobile)
     }
 
-    func testAENumberWithHinduArabicNumerals() {
-        do {
-            let phoneNumber1 = try phoneNumberKit.parse("+٩٧١٥٠٠٥٠٠٥٥٠", withRegion: "AE")
-            XCTAssertNotNil(phoneNumber1)
-            let phoneNumberInternationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .international)
-            XCTAssertTrue(phoneNumberInternationalFormat1 == "+971 50 050 0550")
-            let phoneNumberNationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .national)
-            XCTAssertTrue(phoneNumberNationalFormat1 == "050 050 0550")
-            let phoneNumberE164Format1 = self.phoneNumberKit.format(phoneNumber1, toType: .e164)
-            XCTAssertTrue(phoneNumberE164Format1 == "+971500500550")
-        } catch {
-            XCTFail()
-        }
+    func testAENumberWithHinduArabicNumerals() throws {
+        let phoneNumber1 = try phoneNumberKit.parse("+٩٧١٥٠٠٥٠٠٥٥٠", withRegion: "AE")
+        let phoneNumberInternationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .international)
+        XCTAssertEqual(phoneNumberInternationalFormat1, "+971 50 050 0550")
+        let phoneNumberNationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .national)
+        XCTAssertEqual(phoneNumberNationalFormat1, "050 050 0550")
+        let phoneNumberE164Format1 = self.phoneNumberKit.format(phoneNumber1, toType: .e164)
+        XCTAssertEqual(phoneNumberE164Format1, "+971500500550")
     }
 
-    func testAENumberWithMixedHinduArabicNumerals() {
-        do {
-            let phoneNumber1 = try phoneNumberKit.parse("+٩٧١5٠٠5٠٠55٠", withRegion: "AE")
-            XCTAssertNotNil(phoneNumber1)
-            let phoneNumberInternationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .international)
-            XCTAssertTrue(phoneNumberInternationalFormat1 == "+971 50 050 0550")
-            let phoneNumberNationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .national)
-            XCTAssertTrue(phoneNumberNationalFormat1 == "050 050 0550")
-            let phoneNumberE164Format1 = self.phoneNumberKit.format(phoneNumber1, toType: .e164)
-            XCTAssertTrue(phoneNumberE164Format1 == "+971500500550")
-        } catch {
-            XCTFail()
-        }
+    func testAENumberWithMixedHinduArabicNumerals() throws {
+        let phoneNumber1 = try phoneNumberKit.parse("+٩٧١5٠٠5٠٠55٠", withRegion: "AE")
+        let phoneNumberInternationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .international)
+        XCTAssertEqual(phoneNumberInternationalFormat1, "+971 50 050 0550")
+        let phoneNumberNationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .national)
+        XCTAssertEqual(phoneNumberNationalFormat1, "050 050 0550")
+        let phoneNumberE164Format1 = self.phoneNumberKit.format(phoneNumber1, toType: .e164)
+        XCTAssertEqual(phoneNumberE164Format1, "+971500500550")
     }
 
-    func testAENumberWithEasternArabicNumerals() {
-        do {
-            let phoneNumber1 = try phoneNumberKit.parse("+۹۷۱۵۰۰۵۰۰۵۵۰", withRegion: "AE")
-            XCTAssertNotNil(phoneNumber1)
-            let phoneNumberInternationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .international)
-            XCTAssertTrue(phoneNumberInternationalFormat1 == "+971 50 050 0550")
-            let phoneNumberNationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .national)
-            XCTAssertTrue(phoneNumberNationalFormat1 == "050 050 0550")
-            let phoneNumberE164Format1 = self.phoneNumberKit.format(phoneNumber1, toType: .e164)
-            XCTAssertTrue(phoneNumberE164Format1 == "+971500500550")
-        } catch {
-            XCTFail()
-        }
+    func testAENumberWithEasternArabicNumerals() throws {
+        let phoneNumber1 = try phoneNumberKit.parse("+۹۷۱۵۰۰۵۰۰۵۵۰", withRegion: "AE")
+        XCTAssertNotNil(phoneNumber1)
+        let phoneNumberInternationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .international)
+        XCTAssertEqual(phoneNumberInternationalFormat1, "+971 50 050 0550")
+        let phoneNumberNationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .national)
+        XCTAssertEqual(phoneNumberNationalFormat1, "050 050 0550")
+        let phoneNumberE164Format1 = self.phoneNumberKit.format(phoneNumber1, toType: .e164)
+        XCTAssertEqual(phoneNumberE164Format1, "+971500500550")
     }
 
-    func testAENumberWithMixedEasternArabicNumerals() {
-        do {
-            let phoneNumber1 = try phoneNumberKit.parse("+۹۷۱5۰۰5۰۰55۰", withRegion: "AE")
-            XCTAssertNotNil(phoneNumber1)
-            let phoneNumberInternationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .international)
-            XCTAssertTrue(phoneNumberInternationalFormat1 == "+971 50 050 0550")
-            let phoneNumberNationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .national)
-            XCTAssertTrue(phoneNumberNationalFormat1 == "050 050 0550")
-            let phoneNumberE164Format1 = self.phoneNumberKit.format(phoneNumber1, toType: .e164)
-            XCTAssertTrue(phoneNumberE164Format1 == "+971500500550")
-        } catch {
-            XCTFail()
-        }
+    func testAENumberWithMixedEasternArabicNumerals() throws {
+        let phoneNumber1 = try phoneNumberKit.parse("+۹۷۱5۰۰5۰۰55۰", withRegion: "AE")
+        let phoneNumberInternationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .international)
+        XCTAssertEqual(phoneNumberInternationalFormat1, "+971 50 050 0550")
+        let phoneNumberNationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .national)
+        XCTAssertEqual(phoneNumberNationalFormat1, "050 050 0550")
+        let phoneNumberE164Format1 = self.phoneNumberKit.format(phoneNumber1, toType: .e164)
+        XCTAssertEqual(phoneNumberE164Format1, "+971500500550")
     }
     
     func testPerformanceSimple() {
@@ -398,12 +321,12 @@ class PhoneNumberKitParsingTests: XCTestCase {
         XCTAssertLessThan(timeInterval, 2)
     }
     
-    func testPerformanceNonOptimizedParsingUsageWithoutDefaultRegion() {
+    func testPerformanceNonOptimizedParsingUsageWithoutDefaultRegion() throws {
         let numberOfParses = 2000
         let startTime = Date()
         var endTime = Date()
         for _ in 0..<numberOfParses {
-            _ = try? self.phoneNumberKit.parse("+5491187654321", ignoreType: true)
+            _ = try self.phoneNumberKit.parse("+5491187654321", ignoreType: true)
         }
         endTime = Date()
         let timeInterval = endTime.timeIntervalSince(startTime)
@@ -427,41 +350,35 @@ class PhoneNumberKitParsingTests: XCTestCase {
         XCTAssertLessThan(timeInterval, 1)
     }
 
-    func testUANumber() {
-        let phoneNumber1 = try? phoneNumberKit.parse("501887766", withRegion: "UA")
+    func testUANumber() throws {
+        let phoneNumber1 = try phoneNumberKit.parse("501887766", withRegion: "UA")
         XCTAssertNotNil(phoneNumber1)
-        let phoneNumberInternationalFormat1 = self.phoneNumberKit.format(phoneNumber1!, toType: .international)
+        let phoneNumberInternationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .international)
         XCTAssertTrue(phoneNumberInternationalFormat1 == "+380 50 188 7766")
-        let phoneNumberNationalFormat1 = self.phoneNumberKit.format(phoneNumber1!, toType: .national)
+        let phoneNumberNationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .national)
         XCTAssertTrue(phoneNumberNationalFormat1 == "050 188 7766")
-        let phoneNumberE164Format1 = self.phoneNumberKit.format(phoneNumber1!, toType: .e164)
+        let phoneNumberE164Format1 = self.phoneNumberKit.format(phoneNumber1, toType: .e164)
         XCTAssertTrue(phoneNumberE164Format1 == "+380501887766")
         
-        let phoneNumber2 = try? phoneNumberKit.parse("050 188 7766", withRegion: "UA")
+        let phoneNumber2 = try phoneNumberKit.parse("050 188 7766", withRegion: "UA")
         XCTAssertNotNil(phoneNumber2)
-        let phoneNumberInternationalFormat2 = self.phoneNumberKit.format(phoneNumber2!, toType: .international)
+        let phoneNumberInternationalFormat2 = self.phoneNumberKit.format(phoneNumber2, toType: .international)
         XCTAssertTrue(phoneNumberInternationalFormat2 == "+380 50 188 7766")
-        let phoneNumberNationalFormat2 = self.phoneNumberKit.format(phoneNumber2!, toType: .national)
+        let phoneNumberNationalFormat2 = self.phoneNumberKit.format(phoneNumber2, toType: .national)
         XCTAssertTrue(phoneNumberNationalFormat2 == "050 188 7766")
-        let phoneNumberE164Format2 = self.phoneNumberKit.format(phoneNumber2!, toType: .e164)
+        let phoneNumberE164Format2 = self.phoneNumberKit.format(phoneNumber2, toType: .e164)
         XCTAssertTrue(phoneNumberE164Format2 == "+380501887766")
     }
     
-    func testExtensionWithCommaParsing() {
-        guard let number = try? phoneNumberKit.parse("+33 612-345-678,22") else {
-            XCTFail()
-            return
-        }
-        XCTAssertEqual(number.type, PhoneNumberType.mobile)
+    func testExtensionWithCommaParsing() throws {
+        let number = try phoneNumberKit.parse("+33 612-345-678,22")
+        XCTAssertEqual(number.type, .mobile)
         XCTAssertEqual(number.numberExtension, "22")
     }
     
-    func testExtensionWithSemiColonParsing() {
-        guard let number = try? phoneNumberKit.parse("+33 612-345-678;22") else {
-            XCTFail()
-            return
-        }
-        XCTAssertEqual(number.type, PhoneNumberType.mobile)
+    func testExtensionWithSemiColonParsing() throws {
+        let number = try phoneNumberKit.parse("+33 612-345-678;22")
+        XCTAssertEqual(number.type, .mobile)
         XCTAssertEqual(number.numberExtension, "22")
     }
 
@@ -473,10 +390,10 @@ class PhoneNumberKitParsingTests: XCTestCase {
     
     func testRegionCountryCodeConflict() {
         XCTAssertThrowsError(try phoneNumberKit.parse("212-2344", withRegion: "US")) { error in
-            XCTAssertEqual(error as? PhoneNumberError, PhoneNumberError.invalidNumber)
+            XCTAssertEqual(error as? PhoneNumberError, .invalidNumber)
         }
         XCTAssertThrowsError(try phoneNumberKit.parse("352-2344", withRegion: "US")) { error in
-            XCTAssertEqual(error as? PhoneNumberError, PhoneNumberError.invalidNumber)
+            XCTAssertEqual(error as? PhoneNumberError, .invalidNumber)
         }
     }
 }


### PR DESCRIPTION
## ℹ️ 
This improves tests in several areas, leading to an overall shorter code - which is a benefit, as 

> the ratio of time spent reading versus writing is well over 10 to 1
>
> ~ Uncle Bob ([source](https://www.goodreads.com/quotes/835238-indeed-the-ratio-of-time-spent-reading-versus-writing-is)).

## 1. Throwing Tests

Before:
```swift
func exampleTest() {
    let phoneNumber1 = try? phoneNumberKit.parse("501887766", withRegion: "UA")
    XCTAssertNotNil(phoneNumber1)
    let phoneNumberInternationalFormat1 = self.phoneNumberKit.format(phoneNumber1!, toType: .international)
}
```

After:
```swift
func exampleTest() throws {
    let phoneNumber1 = try phoneNumberKit.parse("501887766", withRegion: "UA")
    let phoneNumberInternationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .international)
}
```

Benefits
- no force unwrapping, the test would fail immediately at the `try` section
- removal of the `XCTAssertNotNil`

## 2. `XCTAssertTrue` vs `XCTAssertEqual`

Before
```swift
XCTAssertTrue(phoneNumberE164Format2 == "+380501887766")
```

After
```swift
XCTAssertEqual(phoneNumberE164Format2, "+380501887766")
```

Benefits:
- a failed test will no longer just say "assert true failed", but will be more helpful - "XYZ" is not equal to "ABC"

## 3. Type inference 

Before
```swift
XCTAssertEqual(number.type, PhoneNumberType.mobile)
```

after
```swift
XCTAssertEqual(number.type, .mobile)
```

## 4. Other
- `final` keyword
- unnecessary `guard` statements
- etc.
