### PR TITLE
Use Proper Tests LifeCycle

### DIFF
--- a/PhoneNumberKitTests/PartialFormatterTests.swift
+++ b/PhoneNumberKitTests/PartialFormatterTests.swift
@@ -10,11 +10,19 @@
 @testable import PhoneNumberKit
 import XCTest
 
-import PhoneNumberKit
-
 /// Testing partial formatter. Goal is to replicate formatting behaviour of Apple's dialer.
-class PartialFormatterTests: XCTestCase {
-    let phoneNumberKit = PhoneNumberKit()
+final class PartialFormatterTests: XCTestCase {
+    private var phoneNumberKit: PhoneNumberKit!
+
+    override func setUp() {
+        super.setUp()
+        phoneNumberKit = PhoneNumberKit()
+    }
+
+    override func tearDown() {
+        phoneNumberKit = nil
+        super.tearDown()
+    }
 
     // +33689555555
     func testFrenchNumberFromFrenchRegion() {

--- a/PhoneNumberKitTests/PhoneNumber+CodableTests.swift
+++ b/PhoneNumberKitTests/PhoneNumber+CodableTests.swift
@@ -10,7 +10,17 @@ import PhoneNumberKit
 import XCTest
 
 final class PhoneNumberCodableTests: XCTestCase {
-    let phoneNumberKit = PhoneNumberKit()
+    private var phoneNumberKit: PhoneNumberKit!
+
+    override func setUp() {
+        super.setUp()
+        phoneNumberKit = PhoneNumberKit()
+    }
+
+    override func tearDown() {
+        phoneNumberKit = nil
+        super.tearDown()
+    }
 }
 
 extension PhoneNumberCodableTests {

--- a/PhoneNumberKitTests/PhoneNumberKitParsingTests.swift
+++ b/PhoneNumberKitTests/PhoneNumberKitParsingTests.swift
@@ -25,7 +25,6 @@ final class PhoneNumberKitParsingTests: XCTestCase {
     }
 
     func testFailingNumber() {
-        NSLog("msrutek, failing test")
         XCTAssertThrowsError(try self.phoneNumberKit.parse("+5491187654321 ABC123", withRegion: "AR")) { error in
             XCTAssertEqual(error as? PhoneNumberError, .invalidNumber)
         }

--- a/PhoneNumberKitTests/PhoneNumberKitParsingTests.swift
+++ b/PhoneNumberKitTests/PhoneNumberKitParsingTests.swift
@@ -12,17 +12,20 @@ import Foundation
 import XCTest
 
 final class PhoneNumberKitParsingTests: XCTestCase {
-    let phoneNumberKit = PhoneNumberKit()
+    private var phoneNumberKit: PhoneNumberKit!
 
     override func setUp() {
         super.setUp()
+        phoneNumberKit = PhoneNumberKit()
     }
 
     override func tearDown() {
+        phoneNumberKit = nil
         super.tearDown()
     }
 
     func testFailingNumber() {
+        NSLog("msrutek, failing test")
         XCTAssertThrowsError(try self.phoneNumberKit.parse("+5491187654321 ABC123", withRegion: "AR")) { error in
             XCTAssertEqual(error as? PhoneNumberError, .invalidNumber)
         }

--- a/PhoneNumberKitTests/PhoneNumberKitTests.swift
+++ b/PhoneNumberKitTests/PhoneNumberKitTests.swift
@@ -9,16 +9,16 @@
 @testable import PhoneNumberKit
 import XCTest
 
-import PhoneNumberKit
-
-class PhoneNumberKitTests: XCTestCase {
-    let phoneNumberKit = PhoneNumberKit()
+final class PhoneNumberKitTests: XCTestCase {
+    private var phoneNumberKit: PhoneNumberKit!
 
     override func setUp() {
         super.setUp()
+        phoneNumberKit = PhoneNumberKit()
     }
 
     override func tearDown() {
+        phoneNumberKit = nil
         super.tearDown()
     }
 

--- a/PhoneNumberKitTests/PhoneNumberTextFieldTests.swift
+++ b/PhoneNumberKitTests/PhoneNumberTextFieldTests.swift
@@ -8,7 +8,7 @@
 
 #if os(iOS)
 
-@testable import PhoneNumberKit
+import PhoneNumberKit
 import UIKit
 import XCTest
 
@@ -26,46 +26,46 @@ final class PhoneNumberTextFieldTests: XCTestCase {
     }
 
     func testWorksWithPhoneNumberKitInstance() {
-        let tf = PhoneNumberTextField(withPhoneNumberKit: phoneNumberKit)
-        tf.partialFormatter.defaultRegion = "US"
-        tf.text = "4125551212"
-        XCTAssertEqual(tf.text, "(412) 555-1212")
+        let textField = PhoneNumberTextField(withPhoneNumberKit: phoneNumberKit)
+        textField.partialFormatter.defaultRegion = "US"
+        textField.text = "4125551212"
+        XCTAssertEqual(textField.text, "(412) 555-1212")
     }
 
     func testWorksWithFrameAndPhoneNumberKitInstance() {
         let frame = CGRect(x: 10.0, y: 20.0, width: 400.0, height: 250.0)
-        let tf = PhoneNumberTextField(frame: frame, phoneNumberKit: phoneNumberKit)
-        tf.partialFormatter.defaultRegion = "US"
-        XCTAssertEqual(tf.frame, frame)
-        tf.text = "4125551212"
-        XCTAssertEqual(tf.text, "(412) 555-1212")
+        let textField = PhoneNumberTextField(frame: frame, phoneNumberKit: phoneNumberKit)
+        textField.partialFormatter.defaultRegion = "US"
+        XCTAssertEqual(textField.frame, frame)
+        textField.text = "4125551212"
+        XCTAssertEqual(textField.text, "(412) 555-1212")
     }
 
     func testPhoneNumberProperty() {
-        let tf = PhoneNumberTextField(withPhoneNumberKit: phoneNumberKit)
-        tf.partialFormatter.defaultRegion = "US"
-        tf.text = "4125551212"
-        XCTAssertNotNil(tf.phoneNumber)
-        tf.text = ""
-        XCTAssertNil(tf.phoneNumber)
+        let textField = PhoneNumberTextField(withPhoneNumberKit: phoneNumberKit)
+        textField.partialFormatter.defaultRegion = "US"
+        textField.text = "4125551212"
+        XCTAssertNotNil(textField.phoneNumber)
+        textField.text = ""
+        XCTAssertNil(textField.phoneNumber)
     }
 
     func testUSPhoneNumberWithFlag() {
-        let tf = PhoneNumberTextField(withPhoneNumberKit: phoneNumberKit)
-        tf.partialFormatter.defaultRegion = "US"
-        tf.withFlag = true
-        tf.text = "4125551212"
-        XCTAssertNotNil(tf.flagButton)
-        XCTAssertEqual(tf.flagButton.titleLabel?.text, "🇺🇸 ")
+        let textField = PhoneNumberTextField(withPhoneNumberKit: phoneNumberKit)
+        textField.partialFormatter.defaultRegion = "US"
+        textField.withFlag = true
+        textField.text = "4125551212"
+        XCTAssertNotNil(textField.flagButton)
+        XCTAssertEqual(textField.flagButton.titleLabel?.text, "🇺🇸 ")
     }
 
     func testNonUSPhoneNumberWithFlag() {
-        let tf = PhoneNumberTextField(withPhoneNumberKit: phoneNumberKit)
-        tf.partialFormatter.defaultRegion = "US"
-        tf.withFlag = true
-        tf.text = "5872170177"
-        XCTAssertNotNil(tf.flagButton)
-        XCTAssertEqual(tf.flagButton.titleLabel?.text, "🇨🇦 ")
+        let textField = PhoneNumberTextField(withPhoneNumberKit: phoneNumberKit)
+        textField.partialFormatter.defaultRegion = "US"
+        textField.withFlag = true
+        textField.text = "5872170177"
+        XCTAssertNotNil(textField.flagButton)
+        XCTAssertEqual(textField.flagButton.titleLabel?.text, "🇨🇦 ")
     }
 }
 

--- a/PhoneNumberKitTests/PhoneNumberTextFieldTests.swift
+++ b/PhoneNumberKitTests/PhoneNumberTextFieldTests.swift
@@ -12,19 +12,29 @@
 import UIKit
 import XCTest
 
-class PhoneNumberTextFieldTests: XCTestCase {
+final class PhoneNumberTextFieldTests: XCTestCase {
+    private var phoneNumberKit: PhoneNumberKit!
+
+    override func setUp() {
+        super.setUp()
+        phoneNumberKit = PhoneNumberKit()
+    }
+
+    override func tearDown() {
+        phoneNumberKit = nil
+        super.tearDown()
+    }
+
     func testWorksWithPhoneNumberKitInstance() {
-        let pnk = PhoneNumberKit()
-        let tf = PhoneNumberTextField(withPhoneNumberKit: pnk)
+        let tf = PhoneNumberTextField(withPhoneNumberKit: phoneNumberKit)
         tf.partialFormatter.defaultRegion = "US"
         tf.text = "4125551212"
         XCTAssertEqual(tf.text, "(412) 555-1212")
     }
 
     func testWorksWithFrameAndPhoneNumberKitInstance() {
-        let pnk = PhoneNumberKit()
         let frame = CGRect(x: 10.0, y: 20.0, width: 400.0, height: 250.0)
-        let tf = PhoneNumberTextField(frame: frame, phoneNumberKit: pnk)
+        let tf = PhoneNumberTextField(frame: frame, phoneNumberKit: phoneNumberKit)
         tf.partialFormatter.defaultRegion = "US"
         XCTAssertEqual(tf.frame, frame)
         tf.text = "4125551212"
@@ -32,8 +42,7 @@ class PhoneNumberTextFieldTests: XCTestCase {
     }
 
     func testPhoneNumberProperty() {
-        let pnk = PhoneNumberKit()
-        let tf = PhoneNumberTextField(withPhoneNumberKit: pnk)
+        let tf = PhoneNumberTextField(withPhoneNumberKit: phoneNumberKit)
         tf.partialFormatter.defaultRegion = "US"
         tf.text = "4125551212"
         XCTAssertNotNil(tf.phoneNumber)
@@ -42,8 +51,7 @@ class PhoneNumberTextFieldTests: XCTestCase {
     }
 
     func testUSPhoneNumberWithFlag() {
-        let pnk = PhoneNumberKit()
-        let tf = PhoneNumberTextField(withPhoneNumberKit: pnk)
+        let tf = PhoneNumberTextField(withPhoneNumberKit: phoneNumberKit)
         tf.partialFormatter.defaultRegion = "US"
         tf.withFlag = true
         tf.text = "4125551212"
@@ -52,8 +60,7 @@ class PhoneNumberTextFieldTests: XCTestCase {
     }
 
     func testNonUSPhoneNumberWithFlag() {
-        let pnk = PhoneNumberKit()
-        let tf = PhoneNumberTextField(withPhoneNumberKit: pnk)
+        let tf = PhoneNumberTextField(withPhoneNumberKit: phoneNumberKit)
         tf.partialFormatter.defaultRegion = "US"
         tf.withFlag = true
         tf.text = "5872170177"


### PR DESCRIPTION
## Use Proper Tests LifeCycle

`XCTestCase` works differently from a standard Swift class. It uses Objective-C runtime in the background.

That is why there should never be stored properties created directly inside of the class.

The reason being, that with having
```swift
final class PhoneNumberTextFieldTests: XCTestCase {
    private let phoneNumberKit = PhoneNumberKit()
    ...
}
```
the test case lifecycle for `n` tests would look like this
- init `phoneNumberKit-1`
- init `phoneNumberKit-2`
- ...
- init `phoneNumberKit-n`
- run `test-1`
- run `test-2`
- ...
- run `test-n`

(Note that the `phoneNumberKit`-s never get deinitialized! ⚠️ )


There are (at least) 2 ways to solve this
1. Create `phoneNumberKit` at the start of each test (this adds visual noise)
2. Define `phoneNumberKit` as an unwrapped optional and use [setUp()](https://developer.apple.com/documentation/xctest/xctest/1500341-setup) to initialize it and [tearDown()](https://developer.apple.com/documentation/xctest/xctest/1500463-teardown) to clear it

I would suggest we go with the second approach.

That way, we would have

- init `phoneNumberKit-1`
- run `test-1`
- deinit `phoneNumberKit-1` ✅  // `deinit` was not called before (at all!)
- init `phoneNumberKit-2` ✅ // all the `init`-s were run before the tests
- run `test-2`
- deinit `phoneNumberKit-2` 
- ...


Source: [iOS Unit Testing by Example by Jon Reid](https://pragprog.com/titles/jrlegios/ios-unit-testing-by-example/) or [his website](https://qualitycoding.org/xctestcase-teardown/) (or better yet - you can try it yourself!)