### PR TITLE
Show Kazakhstan flag in PhoneNumberTextField

### DIFF
--- a/PhoneNumberKit/PartialFormatter.swift
+++ b/PhoneNumberKit/PartialFormatter.swift
@@ -80,12 +80,15 @@ public final class PartialFormatter {
     public var currentRegion: String {
         if ignoreIntlNumbers, currentMetadata?.codeID == "001" {
             return defaultRegion
-        } else if self.phoneNumberKit.countryCode(for: self.defaultRegion) != 1 {
-            return currentMetadata?.codeID ?? "US"
         } else {
-            return self.currentMetadata?.countryCode == 1
+            let countryCode = self.phoneNumberKit.countryCode(for: self.defaultRegion)
+            if countryCode != 1, countryCode != 7 {
+                return currentMetadata?.codeID ?? "US"
+            } else {
+                return self.currentMetadata?.countryCode == 1 || self.currentMetadata?.countryCode == 7
                 ? self.defaultRegion
                 : self.currentMetadata?.codeID ?? self.defaultRegion
+            }
         }
     }
 


### PR DESCRIPTION
Russia and Kazakhstan share the same country code +7. And if you input a valid Kazakhstan phone number in PhoneNumberTextField, it shows a Russian flag. It happens because during parsing it uses main territory for displaying country's flag. 
Added a check that if phone's countryCode is 7, then we should use defaultRegion instead