### PR TITLE
Enable support for visionOS.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,10 @@
-// swift-tools-version: 5.4
+// swift-tools-version: 5.9
 import PackageDescription
 
 let package = Package(
     name: "PhoneNumberKit",
     platforms: [
-        .iOS(.v11), .macOS(.v10_13), .tvOS(.v11), .watchOS(.v4)
+        .iOS(.v12), .macOS(.v10_13), .tvOS(.v12), .watchOS(.v4), .visionOS(.v1)
     ],
     products: [
         .library(name: "PhoneNumberKit", targets: ["PhoneNumberKit"]),

--- a/PhoneNumberKit/UI/CountryCodePickerViewController.swift
+++ b/PhoneNumberKit/UI/CountryCodePickerViewController.swift
@@ -1,4 +1,4 @@
-#if os(iOS)
+#if os(iOS) || os(visionOS)
 
 import UIKit
 
@@ -7,7 +7,7 @@ public protocol CountryCodePickerDelegate: AnyObject {
     func countryCodePickerViewControllerDidPickCountry(_ country: CountryCodePickerViewController.Country)
 }
 
-@available(iOS 11.0, *)
+@available(iOS 11.0, visionOS 1.0, *)
 public class CountryCodePickerViewController: UITableViewController {
 
     lazy var searchController: UISearchController = {

--- a/PhoneNumberKit/UI/PhoneNumberTextField.swift
+++ b/PhoneNumberKit/UI/PhoneNumberTextField.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2021 Roy Marmelstein. All rights reserved.
 //
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
 
 import Foundation
 import UIKit


### PR DESCRIPTION
Just some simple modifications to make this usable in visionOS. 

![example screenshot with PhoneNumberTextField of PhoneNumberKit](https://github.com/marmelroy/PhoneNumberKit/assets/23420208/98777490-e5be-476c-91bc-c9eb2aeed3bf)

![example screenshot with country code selector view](https://github.com/marmelroy/PhoneNumberKit/assets/23420208/b4523c98-3801-4d97-baeb-4900de5001d0)

Of course, users should wrap this with `UIViewRepresentable` for SwiftUI use (which most visionOS apps likely will deal with), and deal with necessary sizing implementations. 

Note that this pull request does modify the SPM package file, which increases minimum os deployment, as well as needing Xcode 15 due to `swift-tools-version` being set to 5.9. It might be possible to add another SPM file that specifically target a swift version.