### PR TITLE
Delegate call fix

### DIFF
--- a/PhoneNumberKit/UI/PhoneNumberTextField.swift
+++ b/PhoneNumberKit/UI/PhoneNumberTextField.swift
@@ -449,11 +449,6 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
     }
 
     open func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        // This allows for the case when a user autocompletes a phone number:
-        if range == NSRange(location: 0, length: 0) && string.isBlank {
-            return true
-        }
-
         guard let text = text else {
             return false
         }
@@ -463,6 +458,11 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
             return false
         }
         guard self.isPartialFormatterEnabled else {
+            return true
+        }
+        
+        // This allows for the case when a user autocompletes a phone number:
+        if range == NSRange(location: 0, length: 0) && string.isBlank {
             return true
         }
 


### PR DESCRIPTION
Steps to reproduce the bug:
1. Create PhoneNumberTextField instance and set it's delegate
2. Tap text field and press space
3. "shouldChangeCharactersIn" method of delegate should be called, but it doesn't