### PR TITLE
Fix minor 'Patten' typo in `PhoneNumberPatterns.countryCodePatten` (renames to `countryCodePattern`)

### DIFF
--- a/PhoneNumberKit/Constants.swift
+++ b/PhoneNumberKit/Constants.swift
@@ -150,5 +150,5 @@ enum PhoneNumberPatterns {
 
     static let validPhoneNumberPattern = "^[0-9０-９٠-٩۰-۹]{2}$|^[+＋]*(?:[-x\u{2010}-\u{2015}\u{2212}\u{30FC}\u{FF0D}-\u{FF0F} \u{00A0}\u{00AD}\u{200B}\u{2060}\u{3000}()\u{FF08}\u{FF09}\u{FF3B}\u{FF3D}.\\[\\]/~\u{2053}\u{223C}\u{FF5E}*]*[0-9\u{FF10}-\u{FF19}\u{0660}-\u{0669}\u{06F0}-\u{06F9}]){3,}[-x\u{2010}-\u{2015}\u{2212}\u{30FC}\u{FF0D}-\u{FF0F} \u{00A0}\u{00AD}\u{200B}\u{2060}\u{3000}()\u{FF08}\u{FF09}\u{FF3B}\u{FF3D}.\\[\\]/~\u{2053}\u{223C}\u{FF5E}*A-Za-z0-9\u{FF10}-\u{FF19}\u{0660}-\u{0669}\u{06F0}-\u{06F9}]*(?:(?:;ext=([0-9０-９٠-٩۰-۹]{1,7})|[  \\t,]*(?:e?xt(?:ensi(?:ó?|ó))?n?|ｅ?ｘｔｎ?|[,xｘX#＃~～;]|int|anexo|ｉｎｔ)[:\\.．]?[  \\t,-]*([0-9０-９٠-٩۰-۹]{1,7})#?|[- ]+([0-9０-９٠-٩۰-۹]{1,5})#)?$)?[,;]*$"
 
-    static let countryCodePatten = "^[a-zA-Z]{2}$"
+    static let countryCodePattern = "^[a-zA-Z]{2}$"
 }

--- a/PhoneNumberKit/PhoneNumberKit.swift
+++ b/PhoneNumberKit/PhoneNumberKit.swift
@@ -284,7 +284,7 @@ public final class PhoneNumberKit {
     ///
     /// - returns: A computed value for the user's current region - based on the iPhone's carrier and if not available, the device region.
     public class func defaultRegionCode() -> String {
-        guard let regex = try? NSRegularExpression(pattern: PhoneNumberPatterns.countryCodePatten) else {
+        guard let regex = try? NSRegularExpression(pattern: PhoneNumberPatterns.countryCodePattern) else {
             return PhoneNumberConstants.defaultCountry
         }
         #if canImport(Contacts)


### PR DESCRIPTION
Hi! its fix minor 'Patten' typo in `PhoneNumberPatterns.countryCodePatten` (renames to `countryCodePattern`)