### PR TITLE
Move privacy manifest from resources to resource bundle

### DIFF
--- a/PhoneNumberKit.podspec
+++ b/PhoneNumberKit.podspec
@@ -27,9 +27,9 @@ Pod::Spec.new do |s|
     core.watchos.deployment_target = '4.0'
     core.source_files = 'PhoneNumberKit/*.{swift}'
     core.resources = [
-      'PhoneNumberKit/Resources/PhoneNumberMetadata.json', 
-      'PhoneNumberKit/Resources/PrivacyInfo.xcprivacy'
+      'PhoneNumberKit/Resources/PhoneNumberMetadata.json'
     ]
+    core.resource_bundles = {'PhoneNumberKitPrivacy' => ['PhoneNumberKit/Resources/PrivacyInfo.xcprivacy']}
   end
 
   s.subspec 'UIKit' do |ui|


### PR DESCRIPTION
Thanks for adding the privacy manifest to the PhoneNumberKit!

This MR aims at fixing the issue where multiple project dependencies provide the privacy manifest, which causes name clash when building as static library (which will be the case if you use binaries and one of many others popular frameworks, e.g. Alamofire, Firebase, other Google frameworks, any analytics, Lottie, Realm etc.)

In the initial implementation, privacy manifest was added in podspec as `resources`. Citing [CocoaPods documentation](https://guides.cocoapods.org/syntax/podspec.html#resources):

> For building the Pod as a static library, we strongly recommend library developers to adopt [resource bundles](http://guides.cocoapods.org/syntax/podspec.html#resource_bundles) as there can be name collisions using the resources attribute.

That's what this MR is doing, moving privacy manifest from resources, to resource bundle, following implementation done e.g. by [Lottie](https://github.com/airbnb/lottie-ios/blob/master/lottie-ios.podspec#L31) or [Realm](https://github.com/realm/realm-swift/blob/master/RealmSwift.podspec#L31).