### PR TITLE
Enable examplePlaceholder without prefill to enable autocomplete compatibility

### DIFF
--- a/PhoneNumberKit/UI/PhoneNumberTextField.swift
+++ b/PhoneNumberKit/UI/PhoneNumberTextField.swift
@@ -73,6 +73,8 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
         }
     }
 
+    public var withPrefixPrefill: Bool = true
+
     public var withFlag: Bool = false {
         didSet {
             leftView = self.withFlag ? self.flagButton : nil
@@ -497,7 +499,7 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
     }
 
     open func textFieldDidBeginEditing(_ textField: UITextField) {
-        if self.withExamplePlaceholder, self.withPrefix, let countryCode = phoneNumberKit.countryCode(for: currentRegion)?.description, (text ?? "").isEmpty {
+        if self.withExamplePlaceholder, self.withPrefix, self.withPrefixPrefill, let countryCode = phoneNumberKit.countryCode(for: currentRegion)?.description, (text ?? "").isEmpty {
             text = "+" + countryCode + " "
         }
         self._delegate?.textFieldDidBeginEditing?(textField)

--- a/PhoneNumberKit/UI/PhoneNumberTextField.swift
+++ b/PhoneNumberKit/UI/PhoneNumberTextField.swift
@@ -499,7 +499,7 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
     }
 
     open func textFieldDidBeginEditing(_ textField: UITextField) {
-        if self.withExamplePlaceholder, self.withPrefix, self.withPrefixPrefill, let countryCode = phoneNumberKit.countryCode(for: currentRegion)?.description, (text ?? "").isEmpty {
+        if self.withExamplePlaceholder, self.withPrefixPrefill, self.withPrefix, let countryCode = phoneNumberKit.countryCode(for: currentRegion)?.description, (text ?? "").isEmpty {
             text = "+" + countryCode + " "
         }
         self._delegate?.textFieldDidBeginEditing?(textField)


### PR DESCRIPTION
- Backwards compatible with existing implementations
- Allows for compatibility of examplePlaceholder with iOS autocomplete, and for an alternate flow that doesn't enforce prefix (useful for dual-sim phones!)

Primary purpose is to enable examplePlaceholder and withPrefix to work with phone number autocomplete for textContentType = .telephoneNumber. iOS disables autocomplete if text is non-empty, so the current implementation is incompatible without this change.

To enable autocomplete when using withPrefix = true, withExamplePlaceholder = true, set withPrefixPrefill = false