### PR TITLE
Rename class `PhoneNumberKit` to `PhoneNumberUtility`

### DIFF
--- a/PhoneNumberKit.xcodeproj/project.pbxproj
+++ b/PhoneNumberKit.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 53;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -28,7 +28,7 @@
 		343B850D1C62A25600918E46 /* PhoneNumberTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 343B850B1C62A25600918E46 /* PhoneNumberTextField.swift */; };
 		34566C9A1BC112C500715E6B /* RegexManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34566C991BC112C500715E6B /* RegexManager.swift */; };
 		346922671BC01DCC0023482F /* MetadataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346922661BC01DCC0023482F /* MetadataManager.swift */; };
-		346922691BC023A60023482F /* PhoneNumberKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346922681BC023A60023482F /* PhoneNumberKit.swift */; };
+		346922691BC023A60023482F /* PhoneNumberUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346922681BC023A60023482F /* PhoneNumberUtility.swift */; };
 		346EF14E1C69C688008C7306 /* PartialFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346EF14D1C69C688008C7306 /* PartialFormatterTests.swift */; };
 		347209901BB80A69004DE6DA /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3472098F1BB80A69004DE6DA /* Foundation.framework */; };
 		34776AA81BE2BF1100400790 /* PhoneNumberKitParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34776AA71BE2BF1100400790 /* PhoneNumberKitParsingTests.swift */; };
@@ -62,7 +62,7 @@
 		C6DF6C591D1B09DD00259F4B /* MetadataTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 342548EF1BE7EED500FBE524 /* MetadataTypes.swift */; };
 		C6DF6C5A1D1B09DD00259F4B /* ParseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3422D9B91BE6A2D500867D02 /* ParseManager.swift */; };
 		C6DF6C5C1D1B09DD00259F4B /* PhoneNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3424187F1BB705B500EE70E7 /* PhoneNumber.swift */; };
-		C6DF6C5D1D1B09DD00259F4B /* PhoneNumberKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346922681BC023A60023482F /* PhoneNumberKit.swift */; };
+		C6DF6C5D1D1B09DD00259F4B /* PhoneNumberUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346922681BC023A60023482F /* PhoneNumberUtility.swift */; };
 		C6DF6C5E1D1B09DD00259F4B /* PhoneNumberParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 342418811BB70F5200EE70E7 /* PhoneNumberParser.swift */; };
 		C6DF6C5F1D1B09DD00259F4B /* RegexManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34566C991BC112C500715E6B /* RegexManager.swift */; };
 		C6DF6CA81D1B145300259F4B /* PhoneNumberKit.h in Headers */ = {isa = PBXBuildFile; fileRef = C6DF6CA71D1B145300259F4B /* PhoneNumberKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -73,7 +73,7 @@
 		C6DF6CB71D1B159A00259F4B /* MetadataTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 342548EF1BE7EED500FBE524 /* MetadataTypes.swift */; };
 		C6DF6CB81D1B159A00259F4B /* ParseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3422D9B91BE6A2D500867D02 /* ParseManager.swift */; };
 		C6DF6CBA1D1B159A00259F4B /* PhoneNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3424187F1BB705B500EE70E7 /* PhoneNumber.swift */; };
-		C6DF6CBB1D1B159A00259F4B /* PhoneNumberKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346922681BC023A60023482F /* PhoneNumberKit.swift */; };
+		C6DF6CBB1D1B159A00259F4B /* PhoneNumberUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346922681BC023A60023482F /* PhoneNumberUtility.swift */; };
 		C6DF6CBC1D1B159A00259F4B /* PhoneNumberParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 342418811BB70F5200EE70E7 /* PhoneNumberParser.swift */; };
 		C6DF6CBD1D1B159A00259F4B /* RegexManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34566C991BC112C500715E6B /* RegexManager.swift */; };
 		C6DF6CD41D1B18CE00259F4B /* PhoneNumberKit.h in Headers */ = {isa = PBXBuildFile; fileRef = C6DF6CA71D1B145300259F4B /* PhoneNumberKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -84,7 +84,7 @@
 		C6DF6CDA1D1B18D800259F4B /* MetadataTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 342548EF1BE7EED500FBE524 /* MetadataTypes.swift */; };
 		C6DF6CDB1D1B18D800259F4B /* ParseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3422D9B91BE6A2D500867D02 /* ParseManager.swift */; };
 		C6DF6CDD1D1B18D800259F4B /* PhoneNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3424187F1BB705B500EE70E7 /* PhoneNumber.swift */; };
-		C6DF6CDE1D1B18D800259F4B /* PhoneNumberKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346922681BC023A60023482F /* PhoneNumberKit.swift */; };
+		C6DF6CDE1D1B18D800259F4B /* PhoneNumberUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346922681BC023A60023482F /* PhoneNumberUtility.swift */; };
 		C6DF6CDF1D1B18D800259F4B /* PhoneNumberParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 342418811BB70F5200EE70E7 /* PhoneNumberParser.swift */; };
 		C6DF6CE01D1B18D800259F4B /* RegexManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34566C991BC112C500715E6B /* RegexManager.swift */; };
 		C9D81F822348025700B75AB7 /* PhoneNumberTextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D81F812348025700B75AB7 /* PhoneNumberTextFieldTests.swift */; };
@@ -124,7 +124,7 @@
 		343B850B1C62A25600918E46 /* PhoneNumberTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PhoneNumberTextField.swift; path = UI/PhoneNumberTextField.swift; sourceTree = "<group>"; usesTabs = 0; };
 		34566C991BC112C500715E6B /* RegexManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegexManager.swift; sourceTree = "<group>"; };
 		346922661BC01DCC0023482F /* MetadataManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MetadataManager.swift; sourceTree = "<group>"; };
-		346922681BC023A60023482F /* PhoneNumberKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhoneNumberKit.swift; sourceTree = "<group>"; };
+		346922681BC023A60023482F /* PhoneNumberUtility.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhoneNumberUtility.swift; sourceTree = "<group>"; };
 		346EF14D1C69C688008C7306 /* PartialFormatterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PartialFormatterTests.swift; sourceTree = "<group>"; };
 		3472098F1BB80A69004DE6DA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		34776AA71BE2BF1100400790 /* PhoneNumberKitParsingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhoneNumberKitParsingTests.swift; sourceTree = "<group>"; };
@@ -230,7 +230,7 @@
 			children = (
 				C6DF6CA71D1B145300259F4B /* PhoneNumberKit.h */,
 				342418691BB6E5A000EE70E7 /* Info.plist */,
-				346922681BC023A60023482F /* PhoneNumberKit.swift */,
+				346922681BC023A60023482F /* PhoneNumberUtility.swift */,
 				A863BC9923801ABC00088460 /* PhoneNumberMetadata.json */,
 				340757841DA03A1700D493A0 /* Metadata */,
 				3422D9B91BE6A2D500867D02 /* ParseManager.swift */,
@@ -514,7 +514,7 @@
 				343B850D1C62A25600918E46 /* PhoneNumberTextField.swift in Sources */,
 				5D14267D238F5842002DD197 /* CountryCodePickerViewController.swift in Sources */,
 				3417BD6B2210AC4900477EE7 /* MetadataParsing.swift in Sources */,
-				346922691BC023A60023482F /* PhoneNumberKit.swift in Sources */,
+				346922691BC023A60023482F /* PhoneNumberUtility.swift in Sources */,
 				343B850C1C62A25600918E46 /* PartialFormatter.swift in Sources */,
 				D51A60A9274416050021EE7E /* PhoneNumber+Codable.swift in Sources */,
 				3422D9BA1BE6A2D500867D02 /* ParseManager.swift in Sources */,
@@ -542,7 +542,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C6DF6C5D1D1B09DD00259F4B /* PhoneNumberKit.swift in Sources */,
+				C6DF6C5D1D1B09DD00259F4B /* PhoneNumberUtility.swift in Sources */,
 				C6B53DA71D94508400E607DD /* NSRegularExpression+Swift.swift in Sources */,
 				C6DF6C5A1D1B09DD00259F4B /* ParseManager.swift in Sources */,
 				C6DF6C5E1D1B09DD00259F4B /* PhoneNumberParser.swift in Sources */,
@@ -566,7 +566,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C6DF6CBB1D1B159A00259F4B /* PhoneNumberKit.swift in Sources */,
+				C6DF6CBB1D1B159A00259F4B /* PhoneNumberUtility.swift in Sources */,
 				C6B53DA51D944F8000E607DD /* NSRegularExpression+Swift.swift in Sources */,
 				C6DF6CB81D1B159A00259F4B /* ParseManager.swift in Sources */,
 				C6DF6CBC1D1B159A00259F4B /* PhoneNumberParser.swift in Sources */,
@@ -591,7 +591,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C6B53DA61D944F8000E607DD /* NSRegularExpression+Swift.swift in Sources */,
-				C6DF6CDE1D1B18D800259F4B /* PhoneNumberKit.swift in Sources */,
+				C6DF6CDE1D1B18D800259F4B /* PhoneNumberUtility.swift in Sources */,
 				C6DF6CDB1D1B18D800259F4B /* ParseManager.swift in Sources */,
 				C6DF6CDF1D1B18D800259F4B /* PhoneNumberParser.swift in Sources */,
 				C6DF6CD61D1B18D800259F4B /* Formatter.swift in Sources */,

--- a/PhoneNumberKit.xcodeproj/project.pbxproj
+++ b/PhoneNumberKit.xcodeproj/project.pbxproj
@@ -19,7 +19,7 @@
 		3420CF5E1BE8959F00FAE34F /* Formatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3420CF5D1BE8959F00FAE34F /* Formatter.swift */; };
 		3422D9BA1BE6A2D500867D02 /* ParseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3422D9B91BE6A2D500867D02 /* ParseManager.swift */; };
 		3424186F1BB6E5A000EE70E7 /* PhoneNumberKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 342418641BB6E5A000EE70E7 /* PhoneNumberKit.framework */; };
-		342418741BB6E5A000EE70E7 /* PhoneNumberKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 342418731BB6E5A000EE70E7 /* PhoneNumberKitTests.swift */; };
+		342418741BB6E5A000EE70E7 /* PhoneNumberUtilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 342418731BB6E5A000EE70E7 /* PhoneNumberUtilityTests.swift */; };
 		342418801BB705B500EE70E7 /* PhoneNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3424187F1BB705B500EE70E7 /* PhoneNumber.swift */; };
 		342418821BB70F5200EE70E7 /* PhoneNumberParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 342418811BB70F5200EE70E7 /* PhoneNumberParser.swift */; };
 		342548F01BE7EED500FBE524 /* MetadataTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 342548EF1BE7EED500FBE524 /* MetadataTypes.swift */; };
@@ -31,7 +31,7 @@
 		346922691BC023A60023482F /* PhoneNumberUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346922681BC023A60023482F /* PhoneNumberUtility.swift */; };
 		346EF14E1C69C688008C7306 /* PartialFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346EF14D1C69C688008C7306 /* PartialFormatterTests.swift */; };
 		347209901BB80A69004DE6DA /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3472098F1BB80A69004DE6DA /* Foundation.framework */; };
-		34776AA81BE2BF1100400790 /* PhoneNumberKitParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34776AA71BE2BF1100400790 /* PhoneNumberKitParsingTests.swift */; };
+		34776AA81BE2BF1100400790 /* PhoneNumberUtilityParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34776AA71BE2BF1100400790 /* PhoneNumberUtilityParsingTests.swift */; };
 		34AA66021BDD160B00467912 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA66011BDD160B00467912 /* Constants.swift */; };
 		34AA66041BDD448B00467912 /* CoreTelephony.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 34AA66031BDD448B00467912 /* CoreTelephony.framework */; };
 		34CA34522380307300788D7D /* PhoneNumberMetadata.json in Resources */ = {isa = PBXBuildFile; fileRef = A863BC9923801ABC00088460 /* PhoneNumberMetadata.json */; };
@@ -114,7 +114,7 @@
 		342418641BB6E5A000EE70E7 /* PhoneNumberKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PhoneNumberKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		342418691BB6E5A000EE70E7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3424186E1BB6E5A000EE70E7 /* PhoneNumberKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PhoneNumberKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		342418731BB6E5A000EE70E7 /* PhoneNumberKitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneNumberKitTests.swift; sourceTree = "<group>"; };
+		342418731BB6E5A000EE70E7 /* PhoneNumberUtilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneNumberUtilityTests.swift; sourceTree = "<group>"; };
 		342418751BB6E5A000EE70E7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3424187F1BB705B500EE70E7 /* PhoneNumber.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhoneNumber.swift; sourceTree = "<group>"; };
 		342418811BB70F5200EE70E7 /* PhoneNumberParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhoneNumberParser.swift; sourceTree = "<group>"; };
@@ -127,7 +127,7 @@
 		346922681BC023A60023482F /* PhoneNumberUtility.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhoneNumberUtility.swift; sourceTree = "<group>"; };
 		346EF14D1C69C688008C7306 /* PartialFormatterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PartialFormatterTests.swift; sourceTree = "<group>"; };
 		3472098F1BB80A69004DE6DA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
-		34776AA71BE2BF1100400790 /* PhoneNumberKitParsingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhoneNumberKitParsingTests.swift; sourceTree = "<group>"; };
+		34776AA71BE2BF1100400790 /* PhoneNumberUtilityParsingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhoneNumberUtilityParsingTests.swift; sourceTree = "<group>"; };
 		34AA66011BDD160B00467912 /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		34AA66031BDD448B00467912 /* CoreTelephony.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreTelephony.framework; path = System/Library/Frameworks/CoreTelephony.framework; sourceTree = SDKROOT; };
 		34F26FBD2517DCB700B6AF4D /* Bundle+Resources.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Resources.swift"; sourceTree = "<group>"; };
@@ -256,10 +256,10 @@
 		342418721BB6E5A000EE70E7 /* PhoneNumberKitTests */ = {
 			isa = PBXGroup;
 			children = (
-				342418731BB6E5A000EE70E7 /* PhoneNumberKitTests.swift */,
+				342418731BB6E5A000EE70E7 /* PhoneNumberUtilityTests.swift */,
 				D51A60AD27442EF50021EE7E /* PhoneNumber+CodableTests.swift */,
 				346EF14D1C69C688008C7306 /* PartialFormatterTests.swift */,
-				34776AA71BE2BF1100400790 /* PhoneNumberKitParsingTests.swift */,
+				34776AA71BE2BF1100400790 /* PhoneNumberUtilityParsingTests.swift */,
 				342418751BB6E5A000EE70E7 /* Info.plist */,
 				C9D81F812348025700B75AB7 /* PhoneNumberTextFieldTests.swift */,
 			);
@@ -531,8 +531,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				D51A60AE27442EF50021EE7E /* PhoneNumber+CodableTests.swift in Sources */,
-				34776AA81BE2BF1100400790 /* PhoneNumberKitParsingTests.swift in Sources */,
-				342418741BB6E5A000EE70E7 /* PhoneNumberKitTests.swift in Sources */,
+				34776AA81BE2BF1100400790 /* PhoneNumberUtilityParsingTests.swift in Sources */,
+				342418741BB6E5A000EE70E7 /* PhoneNumberUtilityTests.swift in Sources */,
 				346EF14E1C69C688008C7306 /* PartialFormatterTests.swift in Sources */,
 				C9D81F822348025700B75AB7 /* PhoneNumberTextFieldTests.swift in Sources */,
 			);

--- a/PhoneNumberKit/Formatter.swift
+++ b/PhoneNumberKit/Formatter.swift
@@ -11,10 +11,6 @@ import Foundation
 final class Formatter {
     weak var regexManager: RegexManager?
 
-    init(phoneNumberKit: PhoneNumberKit) {
-        self.regexManager = phoneNumberKit.regexManager
-    }
-
     init(regexManager: RegexManager) {
         self.regexManager = regexManager
     }

--- a/PhoneNumberKit/PartialFormatter.swift
+++ b/PhoneNumberKit/PartialFormatter.swift
@@ -11,35 +11,35 @@ import Foundation
 
 /// Partial formatter
 public final class PartialFormatter {
-    private let phoneNumberKit: PhoneNumberKit
+    private let utility: PhoneNumberUtility
 
     weak var metadataManager: MetadataManager?
     weak var parser: PhoneNumberParser?
     weak var regexManager: RegexManager?
 
-    public convenience init(phoneNumberKit: PhoneNumberKit = PhoneNumberKit(),
-                            defaultRegion: String = PhoneNumberKit.defaultRegionCode(),
+    public convenience init(utility: PhoneNumberUtility = PhoneNumberUtility(),
+                            defaultRegion: String = PhoneNumberUtility.defaultRegionCode(),
                             withPrefix: Bool = true,
                             maxDigits: Int? = nil,
                             ignoreIntlNumbers: Bool = false) {
-        self.init(phoneNumberKit: phoneNumberKit,
-                  regexManager: phoneNumberKit.regexManager,
-                  metadataManager: phoneNumberKit.metadataManager,
-                  parser: phoneNumberKit.parseManager.parser,
+        self.init(utility: utility,
+                  regexManager: utility.regexManager,
+                  metadataManager: utility.metadataManager,
+                  parser: utility.parseManager.parser,
                   defaultRegion: defaultRegion,
                   withPrefix: withPrefix,
                   maxDigits: maxDigits,
                   ignoreIntlNumbers: ignoreIntlNumbers)
     }
 
-    init(phoneNumberKit: PhoneNumberKit,
+    init(utility: PhoneNumberUtility,
          regexManager: RegexManager,
          metadataManager: MetadataManager,
          parser: PhoneNumberParser, defaultRegion: String,
          withPrefix: Bool = true,
          maxDigits: Int? = nil,
          ignoreIntlNumbers: Bool = false) {
-        self.phoneNumberKit = phoneNumberKit
+        self.utility = utility
         self.regexManager = regexManager
         self.metadataManager = metadataManager
         self.parser = parser
@@ -80,7 +80,7 @@ public final class PartialFormatter {
     public var currentRegion: String {
         if ignoreIntlNumbers, currentMetadata?.codeID == "001" {
             return defaultRegion
-        } else if self.phoneNumberKit.countryCode(for: self.defaultRegion) != 1 {
+        } else if self.utility.countryCode(for: self.defaultRegion) != 1 {
             return currentMetadata?.codeID ?? "US"
         } else {
             return self.currentMetadata?.countryCode == 1 ?

--- a/PhoneNumberKit/PhoneNumber+Codable.swift
+++ b/PhoneNumberKit/PhoneNumber+Codable.swift
@@ -29,13 +29,13 @@ public enum PhoneNumberEncodingStrategy {
 }
 
 public enum PhoneNumberDecodingUtils {
-    /// The default `PhoneNumberKit` instance used for parsing when decoding, if needed.
-    public static var defaultPhoneNumberKit: () -> PhoneNumberKit = { .init() }
+    /// The default `PhoneNumberUtility` instance used for parsing when decoding, if needed.
+    public static var defaultUtility: () -> PhoneNumberUtility = { .init() }
 }
 
 public enum PhoneNumberEncodingUtils {
-    /// The default `PhoneNumberKit` instance used for formatting when encoding, if needed.
-    public static var defaultPhoneNumberKit: () -> PhoneNumberKit = { .init() }
+    /// The default `PhoneNumberUtility` instance used for formatting when encoding, if needed.
+    public static var defaultUtility: () -> PhoneNumberUtility = { .init() }
 }
 
 public extension JSONDecoder {
@@ -49,13 +49,13 @@ public extension JSONDecoder {
         }
     }
 
-    /// The `PhoneNumberKit` instance used for parsing when decoding, if needed.
-    var phoneNumberKit: () -> PhoneNumberKit {
+    /// The `PhoneNumberUtility` instance used for parsing when decoding, if needed.
+    var phoneNumberUtility: () -> PhoneNumberUtility {
         get {
-            return userInfo[.phoneNumberKit] as? () -> PhoneNumberKit ?? PhoneNumberDecodingUtils.defaultPhoneNumberKit
+            return userInfo[.phoneNumberUtility] as? () -> PhoneNumberUtility ?? PhoneNumberDecodingUtils.defaultUtility
         }
         set {
-            userInfo[.phoneNumberKit] = newValue
+            userInfo[.phoneNumberUtility] = newValue
         }
     }
 }
@@ -71,13 +71,13 @@ public extension JSONEncoder {
         }
     }
 
-    /// The `PhoneNumberKit` instance used for formatting when encoding, if needed.
-    var phoneNumberKit: () -> PhoneNumberKit {
+    /// The `PhoneNumberUtility` instance used for formatting when encoding, if needed.
+    var phoneNumberUtility: () -> PhoneNumberUtility {
         get {
-            return userInfo[.phoneNumberKit] as? () -> PhoneNumberKit ?? PhoneNumberEncodingUtils.defaultPhoneNumberKit
+            return userInfo[.phoneNumberUtility] as? () -> PhoneNumberUtility ?? PhoneNumberEncodingUtils.defaultUtility
         }
         set {
-            userInfo[.phoneNumberKit] = newValue
+            userInfo[.phoneNumberUtility] = newValue
         }
     }
 }
@@ -100,8 +100,8 @@ extension PhoneNumber: Codable {
         case .e164:
             let container = try decoder.singleValueContainer()
             let e164String = try container.decode(String.self)
-            let phoneNumberKit = decoder.userInfo[.phoneNumberKit] as? () -> PhoneNumberKit ?? PhoneNumberDecodingUtils.defaultPhoneNumberKit
-            self = try phoneNumberKit().parse(e164String, ignoreType: true)
+            let utility = decoder.userInfo[.phoneNumberUtility] as? () -> PhoneNumberUtility ?? PhoneNumberDecodingUtils.defaultUtility
+            self = try utility().parse(e164String, ignoreType: true)
         }
     }
 
@@ -119,8 +119,8 @@ extension PhoneNumber: Codable {
             try container.encode(regionID, forKey: .regionID)
         case .e164:
             var container = encoder.singleValueContainer()
-            let phoneNumberKit = encoder.userInfo[.phoneNumberKit] as? () -> PhoneNumberKit ?? PhoneNumberEncodingUtils.defaultPhoneNumberKit
-            let e164String = phoneNumberKit().format(self, toType: .e164)
+            let utility = encoder.userInfo[.phoneNumberUtility] as? () -> PhoneNumberUtility ?? PhoneNumberEncodingUtils.defaultUtility
+            let e164String = utility().format(self, toType: .e164)
             try container.encode(e164String)
         }
     }
@@ -140,5 +140,5 @@ extension CodingUserInfoKey {
     static let phoneNumberDecodingStrategy = Self(rawValue: "com.roymarmelstein.PhoneNumberKit.decoding-strategy")!
     static let phoneNumberEncodingStrategy = Self(rawValue: "com.roymarmelstein.PhoneNumberKit.encoding-strategy")!
 
-    static let phoneNumberKit = Self(rawValue: "com.roymarmelstein.PhoneNumberKit.instance")!
+    static let phoneNumberUtility = Self(rawValue: "com.roymarmelstein.PhoneNumberKit.instance")!
 }

--- a/PhoneNumberKit/PhoneNumber.swift
+++ b/PhoneNumberKit/PhoneNumber.swift
@@ -64,12 +64,12 @@ public extension PhoneNumber {
     }
 }
 
-/// In past versions of PhoneNumberKit you were able to initialize a PhoneNumber object to parse a String. Please use a PhoneNumberKit object's methods.
+/// In past versions of PhoneNumberKit you were able to initialize a PhoneNumber object to parse a String. Please use a PhoneNumberUtility object's methods.
 public extension PhoneNumber {
     /// DEPRECATED.
     /// Parse a string into a phone number object using default region. Can throw.
     /// - Parameter rawNumber: String to be parsed to phone number struct.
-    @available(*, unavailable, message: "use PhoneNumberKit instead to produce PhoneNumbers")
+    @available(*, unavailable, message: "use PhoneNumberUtility instead to produce PhoneNumbers")
     init(rawNumber: String) throws {
         assertionFailure(PhoneNumberError.deprecated.localizedDescription)
         throw PhoneNumberError.deprecated
@@ -79,7 +79,7 @@ public extension PhoneNumber {
     /// Parse a string into a phone number object using custom region. Can throw.
     /// - Parameter rawNumber: String to be parsed to phone number struct.
     /// - Parameter region: ISO 3166 compliant region code.
-    @available(*, unavailable, message: "use PhoneNumberKit instead to produce PhoneNumbers")
+    @available(*, unavailable, message: "use PhoneNumberUtility instead to produce PhoneNumbers")
     init(rawNumber: String, region: String) throws {
         throw PhoneNumberError.deprecated
     }

--- a/PhoneNumberKit/PhoneNumberFormatter.swift
+++ b/PhoneNumberKit/PhoneNumberFormatter.swift
@@ -10,7 +10,7 @@
 import Foundation
 
 open class PhoneNumberFormatter: Foundation.Formatter {
-    public let phoneNumberKit: PhoneNumberKit
+    public let utility: PhoneNumberUtility
 
     private let partialFormatter: PartialFormatter
 
@@ -20,7 +20,7 @@ open class PhoneNumberFormatter: Foundation.Formatter {
 
     /// Override region to set a custom region. Automatically uses the default region code.
     @objc public dynamic
-    var defaultRegion = PhoneNumberKit.defaultRegionCode() {
+    var defaultRegion = PhoneNumberUtility.defaultRegionCode() {
         didSet {
             self.partialFormatter.defaultRegion = self.defaultRegion
         }
@@ -40,15 +40,15 @@ open class PhoneNumberFormatter: Foundation.Formatter {
 
     // MARK: Lifecycle
 
-    public init(phoneNumberKit pnk: PhoneNumberKit = PhoneNumberKit(), defaultRegion: String = PhoneNumberKit.defaultRegionCode(), withPrefix: Bool = true) {
-        self.phoneNumberKit = pnk
-        self.partialFormatter = PartialFormatter(phoneNumberKit: self.phoneNumberKit, defaultRegion: defaultRegion, withPrefix: withPrefix)
+    public init(utility: PhoneNumberUtility = PhoneNumberUtility(), defaultRegion: String = PhoneNumberUtility.defaultRegionCode(), withPrefix: Bool = true) {
+        self.utility = utility
+        self.partialFormatter = PartialFormatter(utility: self.utility, defaultRegion: defaultRegion, withPrefix: withPrefix)
         super.init()
     }
 
     public required init?(coder aDecoder: NSCoder) {
-        self.phoneNumberKit = PhoneNumberKit()
-        self.partialFormatter = PartialFormatter(phoneNumberKit: self.phoneNumberKit, defaultRegion: self.defaultRegion, withPrefix: self.withPrefix)
+        self.utility = PhoneNumberUtility()
+        self.partialFormatter = PartialFormatter(utility: self.utility, defaultRegion: self.defaultRegion, withPrefix: self.withPrefix)
         super.init(coder: aDecoder)
     }
 }
@@ -60,7 +60,7 @@ open class PhoneNumberFormatter: Foundation.Formatter {
 extension PhoneNumberFormatter {
     override open func string(for obj: Any?) -> String? {
         if let pn = obj as? PhoneNumber {
-            return self.phoneNumberKit.format(pn, toType: self.withPrefix ? .international : .national)
+            return self.utility.format(pn, toType: self.withPrefix ? .international : .national)
         }
         if let str = obj as? String {
             return self.partialFormatter.formatPartial(str)
@@ -71,7 +71,7 @@ extension PhoneNumberFormatter {
     override open func getObjectValue(_ obj: AutoreleasingUnsafeMutablePointer<AnyObject?>?, for string: String, errorDescription error: AutoreleasingUnsafeMutablePointer<NSString?>?) -> Bool {
         if self.generatesPhoneNumber {
             do {
-                obj?.pointee = try self.phoneNumberKit.parse(string) as AnyObject?
+                obj?.pointee = try self.utility.parse(string) as AnyObject?
                 return true
             } catch let e {
                 error?.pointee = e.localizedDescription as NSString

--- a/PhoneNumberKit/PhoneNumberUtility.swift
+++ b/PhoneNumberKit/PhoneNumberUtility.swift
@@ -13,7 +13,7 @@ import Contacts
 
 public typealias MetadataCallback = () throws -> Data?
 
-public final class PhoneNumberKit {
+public final class PhoneNumberUtility {
     // Manager objects
     let metadataManager: MetadataManager
     let parseManager: ParseManager
@@ -21,7 +21,7 @@ public final class PhoneNumberKit {
 
     // MARK: Lifecycle
 
-    public init(metadataCallback: @escaping MetadataCallback = PhoneNumberKit.defaultMetadataCallback) {
+    public init(metadataCallback: @escaping MetadataCallback = defaultMetadataCallback) {
         self.metadataManager = MetadataManager(metadataCallback: metadataCallback)
         self.parseManager = ParseManager(metadataManager: self.metadataManager, regexManager: self.regexManager)
     }
@@ -35,7 +35,7 @@ public final class PhoneNumberKit {
     ///   - region: ISO 3166 compliant region code.
     ///   - ignoreType: Avoids number type checking for faster performance.
     /// - Returns: PhoneNumber object.
-    public func parse(_ numberString: String, withRegion region: String = PhoneNumberKit.defaultRegionCode(), ignoreType: Bool = false) throws -> PhoneNumber {
+    public func parse(_ numberString: String, withRegion region: String = defaultRegionCode(), ignoreType: Bool = false) throws -> PhoneNumber {
         try self.parseManager.parse(numberString, withRegion: region, ignoreType: ignoreType)
     }
 
@@ -46,7 +46,7 @@ public final class PhoneNumberKit {
     /// - parameter ignoreType:   Avoids number type checking for faster performance.
     ///
     /// - returns: array of PhoneNumber objects.
-    public func parse(_ numberStrings: [String], withRegion region: String = PhoneNumberKit.defaultRegionCode(), ignoreType: Bool = false, shouldReturnFailedEmptyNumbers: Bool = false) -> [PhoneNumber] {
+    public func parse(_ numberStrings: [String], withRegion region: String = defaultRegionCode(), ignoreType: Bool = false, shouldReturnFailedEmptyNumbers: Bool = false) -> [PhoneNumber] {
         return self.parseManager.parseMultiple(numberStrings, withRegion: region, ignoreType: ignoreType, shouldReturnFailedEmptyNumbers: shouldReturnFailedEmptyNumbers)
     }
 
@@ -59,7 +59,7 @@ public final class PhoneNumberKit {
     ///   - region: ISO 3166 compliant region code.
     ///   - ignoreType: Avoids number type checking for faster performance.
     /// - Returns: Bool
-    public func isValidPhoneNumber(_ numberString: String, withRegion region: String = PhoneNumberKit.defaultRegionCode(), ignoreType: Bool = false) -> Bool {
+    public func isValidPhoneNumber(_ numberString: String, withRegion region: String = defaultRegionCode(), ignoreType: Bool = false) -> Bool {
         return (try? self.parse(numberString, withRegion: region, ignoreType: ignoreType)) != nil
     }
 
@@ -347,17 +347,15 @@ public final class PhoneNumberKit {
 }
 
 #if canImport(UIKit)
-public extension PhoneNumberKit {
-    /// Configuration for the CountryCodePicker presented from PhoneNumberTextField if `withDefaultPickerUI` is `true`
-    enum CountryCodePicker {
-        /// Common Country Codes are shown below the Current section in the CountryCodePicker by default
-        public static var commonCountryCodes: [String] = []
+/// Configuration for the CountryCodePicker presented from PhoneNumberTextField if `withDefaultPickerUI` is `true`
+public enum CountryCodePicker {
+    /// Common Country Codes are shown below the Current section in the CountryCodePicker by default
+    public static var commonCountryCodes: [String] = []
 
-        /// When the Picker is shown from the textfield it is presented modally
-        public static var forceModalPresentation: Bool = false
+    /// When the Picker is shown from the textfield it is presented modally
+    public static var forceModalPresentation: Bool = false
 
-        /// Set the search bar of the Picker to always visible
-        public static var alwaysShowsSearchBar: Bool = false
-    }
+    /// Set the search bar of the Picker to always visible
+    public static var alwaysShowsSearchBar: Bool = false
 }
 #endif

--- a/PhoneNumberKit/PhoneNumberUtility.swift
+++ b/PhoneNumberKit/PhoneNumberUtility.swift
@@ -80,7 +80,7 @@ public final class PhoneNumberUtility {
             }
             return "+\(phoneNumber.countryCode)\(formattedNationalNumber)"
         } else {
-            let formatter = Formatter(phoneNumberKit: self)
+            let formatter = Formatter(regexManager: regexManager)
             let regionMetadata = self.metadataManager.mainTerritory(forCode: phoneNumber.countryCode)
             let formattedNationalNumber = formatter.format(phoneNumber: phoneNumber, formatType: formatType, regionMetadata: regionMetadata)
             if formatType == .international, prefix == true {

--- a/PhoneNumberKit/UI/CountryCodePickerViewController.swift
+++ b/PhoneNumberKit/UI/CountryCodePickerViewController.swift
@@ -17,7 +17,7 @@ public class CountryCodePickerViewController: UITableViewController {
         return searchController
     }()
 
-    public let phoneNumberKit: PhoneNumberKit
+    public let utility: PhoneNumberUtility
 
     public let options: CountryCodePickerOptions
 
@@ -28,9 +28,9 @@ public class CountryCodePickerViewController: UITableViewController {
     var hasCurrent = true
     var hasCommon = true
 
-    lazy var allCountries = phoneNumberKit
+    lazy var allCountries = utility
         .allCountries()
-        .compactMap({ Country(for: $0, with: self.phoneNumberKit) })
+        .compactMap({ Country(for: $0, with: self.utility) })
         .sorted(by: { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending })
 
     lazy var countries: [[Country]] = {
@@ -49,11 +49,11 @@ public class CountryCodePickerViewController: UITableViewController {
                 return collection
             }
 
-        let popular = commonCountryCodes.compactMap({ Country(for: $0, with: phoneNumberKit) })
+        let popular = commonCountryCodes.compactMap({ Country(for: $0, with: utility) })
 
         var result: [[Country]] = []
         // Note we should maybe use the user's current carrier's country code?
-        if hasCurrent, let current = Country(for: PhoneNumberKit.defaultRegionCode(), with: phoneNumberKit) {
+        if hasCurrent, let current = Country(for: PhoneNumberUtility.defaultRegionCode(), with: utility) {
             result.append([current])
         }
         hasCommon = hasCommon && !popular.isEmpty
@@ -69,15 +69,15 @@ public class CountryCodePickerViewController: UITableViewController {
 
     lazy var cancelButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(dismissAnimated))
 
-    /// Init with a phone number kit instance. Because a PhoneNumberKit initialization is expensive you can must pass a pre-initialized instance to avoid incurring perf penalties.
+    /// Init with a phone number kit instance. Because a `PhoneNumberUtility` initialization is expensive you can must pass a pre-initialized instance to avoid incurring perf penalties.
     ///
-    /// - parameter phoneNumberKit: A PhoneNumberKit instance to be used by the text field.
-    /// - parameter commonCountryCodes: An array of country codes to display in the section below the current region section. defaults to `PhoneNumberKit.CountryCodePicker.commonCountryCodes`
+    /// - parameter utility: A `PhoneNumberUtility` instance to be used by the text field.
+    /// - parameter commonCountryCodes: An array of country codes to display in the section below the current region section. defaults to `PhoneNumberUtility.CountryCodePicker.commonCountryCodes`
     public init(
-        phoneNumberKit: PhoneNumberKit,
+        utility: PhoneNumberUtility,
         options: CountryCodePickerOptions?,
-        commonCountryCodes: [String] = PhoneNumberKit.CountryCodePicker.commonCountryCodes) {
-        self.phoneNumberKit = phoneNumberKit
+        commonCountryCodes: [String] = CountryCodePicker.commonCountryCodes) {
+        self.utility = utility
         self.commonCountryCodes = commonCountryCodes
         self.options = options ?? CountryCodePickerOptions()
         super.init(style: .grouped)
@@ -85,8 +85,8 @@ public class CountryCodePickerViewController: UITableViewController {
     }
 
     required init?(coder aDecoder: NSCoder) {
-        self.phoneNumberKit = PhoneNumberKit()
-        self.commonCountryCodes = PhoneNumberKit.CountryCodePicker.commonCountryCodes
+        self.utility = PhoneNumberUtility()
+        self.commonCountryCodes = CountryCodePicker.commonCountryCodes
         self.options = CountryCodePickerOptions()
         super.init(coder: aDecoder)
         self.commonInit()
@@ -101,7 +101,7 @@ public class CountryCodePickerViewController: UITableViewController {
         searchController.searchBar.backgroundColor = .clear
 
         navigationItem.searchController = searchController
-        navigationItem.hidesSearchBarWhenScrolling = !PhoneNumberKit.CountryCodePicker.alwaysShowsSearchBar
+        navigationItem.hidesSearchBarWhenScrolling = !CountryCodePicker.alwaysShowsSearchBar
 
         definesPresentationContext = true
 
@@ -255,11 +255,11 @@ public extension CountryCodePickerViewController {
         public var name: String
         public var prefix: String
 
-        public init?(for countryCode: String, with phoneNumberKit: PhoneNumberKit) {
+        public init?(for countryCode: String, with utility: PhoneNumberUtility) {
             let flagBase = UnicodeScalar("🇦").value - UnicodeScalar("A").value
             guard
                 let name = (Locale.current as NSLocale).localizedString(forCountryCode: countryCode),
-                let prefix = phoneNumberKit.countryCode(for: countryCode)?.description
+                let prefix = utility.countryCode(for: countryCode)?.description
             else {
                 return nil
             }

--- a/PhoneNumberKit/UI/PhoneNumberTextField.swift
+++ b/PhoneNumberKit/UI/PhoneNumberTextField.swift
@@ -13,7 +13,7 @@ import UIKit
 
 /// Custom text field that formats phone numbers
 open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
-    public let phoneNumberKit: PhoneNumberKit
+    public let utility: PhoneNumberUtility
 
     public lazy var flagButton = UIButton()
 
@@ -39,7 +39,7 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
         super.text = newValue
     }
 
-    private lazy var _defaultRegion: String = PhoneNumberKit.defaultRegionCode()
+    private lazy var _defaultRegion: String = PhoneNumberUtility.defaultRegionCode()
 
     /// Override region to set a custom region. Automatically uses the default region code.
     open var defaultRegion: String {
@@ -147,7 +147,7 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
     }
 
     public private(set) lazy var partialFormatter: PartialFormatter = .init(
-        phoneNumberKit: phoneNumberKit,
+        utility: utility,
         defaultRegion: defaultRegion,
         withPrefix: withPrefix,
         ignoreIntlNumbers: true
@@ -186,7 +186,7 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
     public var isValidNumber: Bool {
         let rawNumber = self.text ?? String()
         do {
-            _ = try phoneNumberKit.parse(rawNumber, withRegion: currentRegion)
+            _ = try utility.parse(rawNumber, withRegion: currentRegion)
             return true
         } catch {
             return false
@@ -198,7 +198,7 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
     public var phoneNumber: PhoneNumber? {
         guard let rawNumber = self.text else { return nil }
         do {
-            return try phoneNumberKit.parse(rawNumber, withRegion: currentRegion)
+            return try utility.parse(rawNumber, withRegion: currentRegion)
         } catch {
             return nil
         }
@@ -219,24 +219,24 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
 
     // MARK: Lifecycle
 
-    /// Init with a phone number kit instance. Because a PhoneNumberKit initialization is expensive,
+    /// Init with a phone number kit instance. Because a `PhoneNumberUtility` initialization is expensive,
     /// you can pass a pre-initialized instance to avoid incurring perf penalties.
     ///
-    /// - parameter phoneNumberKit: A PhoneNumberKit instance to be used by the text field.
+    /// - parameter utility: A `PhoneNumberUtility` instance to be used by the text field.
     ///
     /// - returns: UITextfield
-    public convenience init(withPhoneNumberKit phoneNumberKit: PhoneNumberKit) {
-        self.init(frame: .zero, phoneNumberKit: phoneNumberKit)
+    public convenience init(utility: PhoneNumberUtility) {
+        self.init(frame: .zero, utility: utility)
     }
 
     /// Init with frame and phone number kit instance.
     ///
     /// - parameter frame: UITextfield frame
-    /// - parameter phoneNumberKit: A PhoneNumberKit instance to be used by the text field.
+    /// - parameter utility: A `PhoneNumberUtility` instance to be used by the text field.
     ///
     /// - returns: UITextfield
-    public init(frame: CGRect, phoneNumberKit: PhoneNumberKit) {
-        self.phoneNumberKit = phoneNumberKit
+    public init(frame: CGRect, utility: PhoneNumberUtility) {
+        self.utility = utility
         super.init(frame: frame)
         self.setup()
     }
@@ -247,7 +247,7 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
     ///
     /// - returns: UITextfield
     override public init(frame: CGRect) {
-        self.phoneNumberKit = PhoneNumberKit()
+        self.utility = PhoneNumberUtility()
         super.init(frame: frame)
         self.setup()
     }
@@ -266,7 +266,7 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
     ///     button and the edges of the text field. A positive value increases the distance between the clear button and the
     ///     text field's edges, and a negative value decreases this distance.
     public init(insets: UIEdgeInsets, clearButtonPadding: CGFloat) {
-        self.phoneNumberKit = PhoneNumberKit()
+        self.utility = PhoneNumberUtility()
         self.insets = insets
         self.clearButtonPadding = clearButtonPadding
         super.init(frame: .zero)
@@ -279,7 +279,7 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
     ///
     /// - returns: UITextfield
     public required init(coder aDecoder: NSCoder) {
-        self.phoneNumberKit = PhoneNumberKit()
+        self.utility = PhoneNumberUtility()
         super.init(coder: aDecoder)!
         self.setup()
     }
@@ -291,7 +291,7 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
     }
 
     func internationalPrefix(for countryCode: String) -> String? {
-        guard let countryCode = phoneNumberKit.countryCode(for: currentRegion)?.description else { return nil }
+        guard let countryCode = utility.countryCode(for: currentRegion)?.description else { return nil }
         return "+" + countryCode
     }
 
@@ -301,7 +301,7 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
         if let phoneNumber = phoneNumber,
            let regionCode = phoneNumber.regionID,
            regionCode != currentRegion,
-           phoneNumber.countryCode == phoneNumberKit.countryCode(for: currentRegion) {
+           phoneNumber.countryCode == utility.countryCode(for: currentRegion) {
             _defaultRegion = regionCode
             partialFormatter.defaultRegion = regionCode
         }
@@ -336,7 +336,7 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
         if isEditing, !(self.text ?? "").isEmpty { return } // No need to update a placeholder while the placeholder isn't showing
 
         let format = self.withPrefix ? PhoneNumberFormat.international : .national
-        let example = self.phoneNumberKit.getFormattedExampleNumber(forCountry: self.currentRegion, withFormat: format, withPrefix: self.withPrefix) ?? "12345678"
+        let example = self.utility.getFormattedExampleNumber(forCountry: self.currentRegion, withFormat: format, withPrefix: self.withPrefix) ?? "12345678"
         let font = self.font ?? UIFont.preferredFont(forTextStyle: .body)
         let ph = NSMutableAttributedString(string: example, attributes: [.font: font])
 
@@ -357,10 +357,10 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
 
     @objc func didPressFlagButton() {
         guard withDefaultPickerUI else { return }
-        let vc = CountryCodePickerViewController(phoneNumberKit: phoneNumberKit,
+        let vc = CountryCodePickerViewController(utility: utility,
                                                  options: withDefaultPickerUIOptions)
         vc.delegate = self
-        if let nav = containingViewController?.navigationController, !PhoneNumberKit.CountryCodePicker.forceModalPresentation {
+        if let nav = containingViewController?.navigationController, !CountryCodePicker.forceModalPresentation {
             nav.pushViewController(vc, animated: true)
         } else {
             let nav = UINavigationController(rootViewController: vc)
@@ -499,7 +499,7 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
     }
 
     open func textFieldDidBeginEditing(_ textField: UITextField) {
-        if self.withExamplePlaceholder, self.withPrefixPrefill, self.withPrefix, let countryCode = phoneNumberKit.countryCode(for: currentRegion)?.description, (text ?? "").isEmpty {
+        if self.withExamplePlaceholder, self.withPrefixPrefill, self.withPrefix, let countryCode = utility.countryCode(for: currentRegion)?.description, (text ?? "").isEmpty {
             text = "+" + countryCode + " "
         }
         self._delegate?.textFieldDidBeginEditing?(textField)
@@ -539,7 +539,7 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
     }
 
     private func updateTextFieldDidEndEditing(_ textField: UITextField) {
-        if self.withExamplePlaceholder, self.withPrefix, let countryCode = phoneNumberKit.countryCode(for: currentRegion)?.description,
+        if self.withExamplePlaceholder, self.withPrefix, let countryCode = utility.countryCode(for: currentRegion)?.description,
            let text = textField.text,
            text == internationalPrefix(for: countryCode) {
             textField.text = ""
@@ -558,7 +558,7 @@ extension PhoneNumberTextField: CountryCodePickerDelegate {
         updateFlag()
         updatePlaceholder()
 
-        if let nav = containingViewController?.navigationController, !PhoneNumberKit.CountryCodePicker.forceModalPresentation {
+        if let nav = containingViewController?.navigationController, !CountryCodePicker.forceModalPresentation {
             nav.popViewController(animated: true)
         } else {
             containingViewController?.dismiss(animated: true)

--- a/PhoneNumberKitTests/PartialFormatterTests.swift
+++ b/PhoneNumberKitTests/PartialFormatterTests.swift
@@ -12,22 +12,22 @@ import XCTest
 
 /// Testing partial formatter. Goal is to replicate formatting behaviour of Apple's dialer.
 final class PartialFormatterTests: XCTestCase {
-    private var phoneNumberKit: PhoneNumberKit!
+    private var utility: PhoneNumberUtility!
 
     override func setUp() {
         super.setUp()
-        phoneNumberKit = PhoneNumberKit()
+        utility = PhoneNumberUtility()
     }
 
     override func tearDown() {
-        phoneNumberKit = nil
+        utility = nil
         super.tearDown()
     }
 
     /// Input: +33689555555
     /// Expected result: https://libphonenumber.appspot.com/phonenumberparser?number=%2B33689555555&country=FR
     func testFrenchNumberFromFrenchRegion() {
-        let partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: "FR")
+        let partialFormatter = PartialFormatter(utility: utility, defaultRegion: "FR")
         var testNumber = "+"
         XCTAssertEqual(partialFormatter.formatPartial(testNumber), "+")
         testNumber = "+3"
@@ -57,7 +57,7 @@ final class PartialFormatterTests: XCTestCase {
     /// Input: 0033689555555
     /// Expected result: https://libphonenumber.appspot.com/phonenumberparser?number=0033689555555&country=FR
     func testFrenchNumberIDDFromFrenchRegion() {
-        let partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: "FR")
+        let partialFormatter = PartialFormatter(utility: utility, defaultRegion: "FR")
         var testNumber = "0"
         XCTAssertEqual(partialFormatter.formatPartial(testNumber), "0")
         testNumber = "00"
@@ -89,7 +89,7 @@ final class PartialFormatterTests: XCTestCase {
     // 268 464 1234
     // Test for number that is not the country code's main country
     func testAntiguaNumber() {
-        let partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: "AG")
+        let partialFormatter = PartialFormatter(utility: utility, defaultRegion: "AG")
         var number = "2"
         XCTAssertEqual(partialFormatter.formatPartial(number), "2")
         number = "26"
@@ -115,7 +115,7 @@ final class PartialFormatterTests: XCTestCase {
     // Input: +33689555555
     // Expected result: https://libphonenumber.appspot.com/phonenumberparser?number=%2B33689555555&country=US
     func testFrenchNumberFromAmericanRegion() {
-        let partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: "US")
+        let partialFormatter = PartialFormatter(utility: utility, defaultRegion: "US")
         var testNumber = "+"
         XCTAssertEqual(partialFormatter.formatPartial(testNumber), "+")
         testNumber = "+3"
@@ -145,7 +145,7 @@ final class PartialFormatterTests: XCTestCase {
     // Input: 01133689555555
     // Expected result: https://libphonenumber.appspot.com/phonenumberparser?number=01133689555555&country=US
     func testFrenchNumberIDDFromAmericanRegion() {
-        let partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: "US")
+        let partialFormatter = PartialFormatter(utility: utility, defaultRegion: "US")
         var testNumber = "0"
         XCTAssertEqual(partialFormatter.formatPartial(testNumber), "0")
         testNumber = "01"
@@ -177,7 +177,7 @@ final class PartialFormatterTests: XCTestCase {
     }
 
     func testInvalidNumberNotANumber() {
-        let partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: "US")
+        let partialFormatter = PartialFormatter(utility: utility, defaultRegion: "US")
         let testNumber = "ae4c08c6-be33-40ef-a417-e5166e307b5e"
         XCTAssertEqual(partialFormatter.formatPartial(testNumber), "ae4c08c6-be33-40ef-a417-e5166e307b5e")
     }
@@ -185,7 +185,7 @@ final class PartialFormatterTests: XCTestCase {
     /// Input: +390549555555
     /// Expected result: https://libphonenumber.appspot.com/phonenumberparser?number=%2B390549555555&country=US
     func testItalianLeadingZeroFromUS() {
-        let partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: "US")
+        let partialFormatter = PartialFormatter(utility: utility, defaultRegion: "US")
         var testNumber = "+"
         XCTAssertEqual(partialFormatter.formatPartial(testNumber), "+")
         testNumber = "+3"
@@ -217,7 +217,7 @@ final class PartialFormatterTests: XCTestCase {
     /// Input: 0689555555
     /// Expected result: https://libphonenumber.appspot.com/phonenumberparser?number=0689555555&country=FR
     func testFrenchNumberLocal() {
-        let partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: "FR")
+        let partialFormatter = PartialFormatter(utility: utility, defaultRegion: "FR")
         var testNumber = "0"
         XCTAssertEqual(partialFormatter.formatPartial(testNumber), "0")
         testNumber = "06"
@@ -241,7 +241,7 @@ final class PartialFormatterTests: XCTestCase {
     }
 
     func testUSTollFreeNumber() {
-        let partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: "US")
+        let partialFormatter = PartialFormatter(utility: utility, defaultRegion: "US")
         var testNumber = "8"
         XCTAssertEqual(partialFormatter.formatPartial(testNumber), "8")
         testNumber = "80"
@@ -269,7 +269,7 @@ final class PartialFormatterTests: XCTestCase {
     // Expected result: https://libphonenumber.appspot.com/phonenumberparser?number=3148525477&country=US
     func testUSNumberStartingWithThree() {
         // 3148525477
-        let partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: "US")
+        let partialFormatter = PartialFormatter(utility: utility, defaultRegion: "US")
         var testNumber = "3"
         XCTAssertEqual(partialFormatter.formatPartial(testNumber), "3")
         testNumber = "31"
@@ -296,7 +296,7 @@ final class PartialFormatterTests: XCTestCase {
     // Input: 4372234563
     // Expected result: https://libphonenumber.appspot.com/phonenumberparser?number=4372234563&country=CA
     func testCANumber() {
-        let partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: "CA")
+        let partialFormatter = PartialFormatter(utility: utility, defaultRegion: "CA")
         var testNumber = "4"
         XCTAssertEqual(partialFormatter.formatPartial(testNumber), "4")
         testNumber = "43"
@@ -321,7 +321,7 @@ final class PartialFormatterTests: XCTestCase {
 
     // 07739555555
     func testUKMobileNumber() {
-        let partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: "GB")
+        let partialFormatter = PartialFormatter(utility: utility, defaultRegion: "GB")
         var testNumber = "0"
         XCTAssertEqual(partialFormatter.formatPartial(testNumber), "0")
         testNumber = "07"
@@ -348,7 +348,7 @@ final class PartialFormatterTests: XCTestCase {
 
     // 07739555555,9
     func testUKMobileNumberWithDigitsPausesAndWaits() {
-        let partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: "GB")
+        let partialFormatter = PartialFormatter(utility: utility, defaultRegion: "GB")
         var testNumber = "0"
         XCTAssertEqual(partialFormatter.formatPartial(testNumber), "0")
         testNumber = "07"
@@ -396,7 +396,7 @@ final class PartialFormatterTests: XCTestCase {
     /// Input: +٩٧١٥٠٠٥٠٠٥٥٠ (+971500500550)
     /// Expected result: https://libphonenumber.appspot.com/phonenumberparser?number=%2B971500500550&country=AE
     func testAENumberWithHinduArabicNumerals() {
-        let partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: "AE")
+        let partialFormatter = PartialFormatter(utility: utility, defaultRegion: "AE")
         var testNumber = "+"
         XCTAssertEqual(partialFormatter.formatPartial(testNumber), "+")
         testNumber = "+٩"
@@ -428,7 +428,7 @@ final class PartialFormatterTests: XCTestCase {
     /// Input: +٩٧١5٠٠5٠٠55٠ (+971500500550)
     /// Expected result: https://libphonenumber.appspot.com/phonenumberparser?number=%2B971500500550&country=AE
     func testAENumberWithMixedHinduArabicNumerals() {
-        let partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: "AE")
+        let partialFormatter = PartialFormatter(utility: utility, defaultRegion: "AE")
         var testNumber = "+"
         XCTAssertEqual(partialFormatter.formatPartial(testNumber), "+")
         testNumber = "+٩"
@@ -460,7 +460,7 @@ final class PartialFormatterTests: XCTestCase {
     /// Input: +۹۷۱۵۰۰۵۰۰۵۵۰ (+971500500550)
     /// Expected result: https://libphonenumber.appspot.com/phonenumberparser?number=%2B971500500550&country=AE
     func testAENumberWithEasternArabicNumerals() {
-        let partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: "AE")
+        let partialFormatter = PartialFormatter(utility: utility, defaultRegion: "AE")
         var testNumber = "+"
         XCTAssertEqual(partialFormatter.formatPartial(testNumber), "+")
         testNumber = "+۹"
@@ -492,7 +492,7 @@ final class PartialFormatterTests: XCTestCase {
     /// Input: +۹۷۱5۰۰5۰۰55۰ (+971500500550)
     /// Expected result: https://libphonenumber.appspot.com/phonenumberparser?number=%2B971500500550&country=AE
     func testAENumberWithMixedEasternArabicNumerals() {
-        let partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: "AE")
+        let partialFormatter = PartialFormatter(utility: utility, defaultRegion: "AE")
         var testNumber = "+"
         XCTAssertEqual(partialFormatter.formatPartial(testNumber), "+")
         testNumber = "+۹"
@@ -522,7 +522,7 @@ final class PartialFormatterTests: XCTestCase {
     }
 
     func testWithPrefixDisabled() {
-        let partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: "CZ")
+        let partialFormatter = PartialFormatter(utility: utility, defaultRegion: "CZ")
         partialFormatter.withPrefix = false
         let formatted = partialFormatter.formatPartial("+420777123456")
         XCTAssertEqual(formatted, "777 123 456")
@@ -531,19 +531,19 @@ final class PartialFormatterTests: XCTestCase {
     // MARK: region prediction
 
     func testMinimalFrenchNumber() {
-        let partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: "US")
+        let partialFormatter = PartialFormatter(utility: utility, defaultRegion: "US")
         _ = partialFormatter.formatPartial("+33")
         XCTAssertEqual(partialFormatter.currentRegion, "FR")
     }
 
     func testMinimalUSNumberFromFrance() {
-        let partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: "FR")
+        let partialFormatter = PartialFormatter(utility: utility, defaultRegion: "FR")
         _ = partialFormatter.formatPartial("+1")
         XCTAssertEqual(partialFormatter.currentRegion, "US")
     }
 
     func testRegionResetsWithEachCallToFormatPartial() {
-        let partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: "DE")
+        let partialFormatter = PartialFormatter(utility: utility, defaultRegion: "DE")
         _ = partialFormatter.formatPartial("+1 212 555 1212")
         XCTAssertEqual(partialFormatter.currentRegion, "US")
         _ = partialFormatter.formatPartial("invalid raw number")
@@ -555,7 +555,7 @@ final class PartialFormatterTests: XCTestCase {
     func testMaxDigits() {
         func test(_ maxDigits: Int?, _ formatted: String) {
             let partialFormatter = PartialFormatter(
-                phoneNumberKit: phoneNumberKit,
+                utility: utility,
                 defaultRegion: "US",
                 maxDigits: maxDigits
             )
@@ -588,7 +588,7 @@ final class PartialFormatterTests: XCTestCase {
 
     // *144
     func testBrazilianOperatorService() {
-        let partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: "BR")
+        let partialFormatter = PartialFormatter(utility: utility, defaultRegion: "BR")
         var testNumber = "*"
         XCTAssertEqual(partialFormatter.formatPartial(testNumber), "*")
         testNumber = "*1"
@@ -601,7 +601,7 @@ final class PartialFormatterTests: XCTestCase {
 
     // *#06#
     func testImeiCodeRetrieval() {
-        let partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: "BR")
+        let partialFormatter = PartialFormatter(utility: utility, defaultRegion: "BR")
         var testNumber = "*"
         XCTAssertEqual(partialFormatter.formatPartial(testNumber), "*")
         testNumber = "*#"
@@ -616,7 +616,7 @@ final class PartialFormatterTests: XCTestCase {
 
     // *#*6#
     func testAsteriskShouldNotBeRejectedInTheMiddle() {
-        let partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: "BR")
+        let partialFormatter = PartialFormatter(utility: utility, defaultRegion: "BR")
         var testNumber = "*"
         XCTAssertEqual(partialFormatter.formatPartial(testNumber), "*")
         testNumber = "*#"
@@ -631,7 +631,7 @@ final class PartialFormatterTests: XCTestCase {
 
     // *#*6#
     func testPoundShouldNotBeRejectedInTheMiddle() {
-        let partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: "BR")
+        let partialFormatter = PartialFormatter(utility: utility, defaultRegion: "BR")
         var testNumber = "*"
         XCTAssertEqual(partialFormatter.formatPartial(testNumber), "*")
         testNumber = "*#"
@@ -649,7 +649,7 @@ final class PartialFormatterTests: XCTestCase {
 
     // 650,9,2
     func testPausedPhoneNumber() {
-        let partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: "US")
+        let partialFormatter = PartialFormatter(utility: utility, defaultRegion: "US")
         var testNumber = "6"
         XCTAssertEqual(partialFormatter.formatPartial(testNumber), "6")
         testNumber = "65"
@@ -668,7 +668,7 @@ final class PartialFormatterTests: XCTestCase {
 
     // 121;4
     func testWaitPhoneNumber() {
-        let partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: "US")
+        let partialFormatter = PartialFormatter(utility: utility, defaultRegion: "US")
         var testNumber = "1"
         XCTAssertEqual(partialFormatter.formatPartial(testNumber), "1")
         testNumber = "12"
@@ -682,13 +682,13 @@ final class PartialFormatterTests: XCTestCase {
     }
 
     func testMinimalRUNumberFromESRegion() {
-        let partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: "ES")
+        let partialFormatter = PartialFormatter(utility: utility, defaultRegion: "ES")
         _ = partialFormatter.formatPartial("+7")
         XCTAssertEqual(partialFormatter.currentRegion, "RU")
     }
 
     func testMinimalRUNumberFromUSRegion() {
-        let partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: "US")
+        let partialFormatter = PartialFormatter(utility: utility, defaultRegion: "US")
         _ = partialFormatter.formatPartial("+7")
         XCTAssertEqual(partialFormatter.currentRegion, "RU")
     }

--- a/PhoneNumberKitTests/PhoneNumber+CodableTests.swift
+++ b/PhoneNumberKitTests/PhoneNumber+CodableTests.swift
@@ -10,15 +10,15 @@ import PhoneNumberKit
 import XCTest
 
 final class PhoneNumberCodableTests: XCTestCase {
-    private var phoneNumberKit: PhoneNumberKit!
+    private var utility: PhoneNumberUtility!
 
     override func setUp() {
         super.setUp()
-        phoneNumberKit = PhoneNumberKit()
+        utility = PhoneNumberUtility()
     }
 
     override func tearDown() {
-        phoneNumberKit = nil
+        utility = nil
         super.tearDown()
     }
 }
@@ -37,7 +37,7 @@ extension PhoneNumberCodableTests {
               "type" : "unknown"
             }
             """,
-            phoneNumberKit.parse("+441632960015", ignoreType: true),
+            utility.parse("+441632960015", ignoreType: true),
             strategy: nil
         )
         try assertDecode(
@@ -52,7 +52,7 @@ extension PhoneNumberCodableTests {
               "type" : "unknown"
             }
             """,
-            phoneNumberKit.parse("+34646990213", ignoreType: true),
+            utility.parse("+34646990213", ignoreType: true),
             strategy: nil
         )
     }
@@ -70,7 +70,7 @@ extension PhoneNumberCodableTests {
               "type" : "unknown"
             }
             """,
-            phoneNumberKit.parse("+441632960015", ignoreType: true),
+            utility.parse("+441632960015", ignoreType: true),
             strategy: .properties
         )
         try assertDecode(
@@ -85,7 +85,7 @@ extension PhoneNumberCodableTests {
               "type" : "unknown"
             }
             """,
-            phoneNumberKit.parse("+34646990213", ignoreType: true),
+            utility.parse("+34646990213", ignoreType: true),
             strategy: .properties
         )
     }
@@ -95,28 +95,28 @@ extension PhoneNumberCodableTests {
             """
             "+441632960015"
             """,
-            phoneNumberKit.parse("+441632960015", ignoreType: true),
+            utility.parse("+441632960015", ignoreType: true),
             strategy: .e164
         )
         try assertDecode(
             """
             "+441632960015"
             """,
-            phoneNumberKit.parse("01632960015", withRegion: "GB", ignoreType: true),
+            utility.parse("01632960015", withRegion: "GB", ignoreType: true),
             strategy: .e164
         )
         try assertDecode(
             """
             "+34646990213"
             """,
-            phoneNumberKit.parse("+34646990213", ignoreType: true),
+            utility.parse("+34646990213", ignoreType: true),
             strategy: .e164
         )
         try assertDecode(
             """
             "+34646990213"
             """,
-            phoneNumberKit.parse("646990213", withRegion: "ES", ignoreType: true),
+            utility.parse("646990213", withRegion: "ES", ignoreType: true),
             strategy: .e164
         )
     }
@@ -125,7 +125,7 @@ extension PhoneNumberCodableTests {
 extension PhoneNumberCodableTests {
     func testEncode_defaultStrategy() throws {
         try assertEncode(
-            phoneNumberKit.parse("+441632960015", ignoreType: true),
+            utility.parse("+441632960015", ignoreType: true),
             """
             {
               "countryCode" : 44,
@@ -140,7 +140,7 @@ extension PhoneNumberCodableTests {
             strategy: nil
         )
         try assertEncode(
-            phoneNumberKit.parse("+34646990213", ignoreType: true),
+            utility.parse("+34646990213", ignoreType: true),
             """
             {
               "countryCode" : 34,
@@ -158,7 +158,7 @@ extension PhoneNumberCodableTests {
 
     func testEncode_propertiesStrategy() throws {
         try assertEncode(
-            phoneNumberKit.parse("+441632960015", ignoreType: true),
+            utility.parse("+441632960015", ignoreType: true),
             """
             {
               "countryCode" : 44,
@@ -173,7 +173,7 @@ extension PhoneNumberCodableTests {
             strategy: .properties
         )
         try assertEncode(
-            phoneNumberKit.parse("+34646990213", ignoreType: true),
+            utility.parse("+34646990213", ignoreType: true),
             """
             {
               "countryCode" : 34,
@@ -191,28 +191,28 @@ extension PhoneNumberCodableTests {
 
     func testEncode_e164Strategy() throws {
         try assertEncode(
-            phoneNumberKit.parse("+441632960015", ignoreType: true),
+            utility.parse("+441632960015", ignoreType: true),
             """
             "+441632960015"
             """,
             strategy: .e164
         )
         try assertEncode(
-            phoneNumberKit.parse("01632960015", withRegion: "GB", ignoreType: true),
+            utility.parse("01632960015", withRegion: "GB", ignoreType: true),
             """
             "+441632960015"
             """,
             strategy: .e164
         )
         try assertEncode(
-            phoneNumberKit.parse("+34646990213", ignoreType: true),
+            utility.parse("+34646990213", ignoreType: true),
             """
             "+34646990213"
             """,
             strategy: .e164
         )
         try assertEncode(
-            phoneNumberKit.parse("646990213", withRegion: "ES", ignoreType: true),
+            utility.parse("646990213", withRegion: "ES", ignoreType: true),
             """
             "+34646990213"
             """,

--- a/PhoneNumberKitTests/PhoneNumberTextFieldTests.swift
+++ b/PhoneNumberKitTests/PhoneNumberTextFieldTests.swift
@@ -13,20 +13,20 @@ import UIKit
 import XCTest
 
 final class PhoneNumberTextFieldTests: XCTestCase {
-    private var phoneNumberKit: PhoneNumberKit!
+    private var utility: PhoneNumberUtility!
 
     override func setUp() {
         super.setUp()
-        phoneNumberKit = PhoneNumberKit()
+        utility = PhoneNumberUtility()
     }
 
     override func tearDown() {
-        phoneNumberKit = nil
+        utility = nil
         super.tearDown()
     }
 
     func testWorksWithPhoneNumberKitInstance() {
-        let textField = PhoneNumberTextField(withPhoneNumberKit: phoneNumberKit)
+        let textField = PhoneNumberTextField(utility: utility)
         textField.partialFormatter.defaultRegion = "US"
         textField.text = "4125551212"
         XCTAssertEqual(textField.text, "(412) 555-1212")
@@ -34,7 +34,7 @@ final class PhoneNumberTextFieldTests: XCTestCase {
 
     func testWorksWithFrameAndPhoneNumberKitInstance() {
         let frame = CGRect(x: 10.0, y: 20.0, width: 400.0, height: 250.0)
-        let textField = PhoneNumberTextField(frame: frame, phoneNumberKit: phoneNumberKit)
+        let textField = PhoneNumberTextField(frame: frame, utility: utility)
         textField.partialFormatter.defaultRegion = "US"
         XCTAssertEqual(textField.frame, frame)
         textField.text = "4125551212"
@@ -42,7 +42,7 @@ final class PhoneNumberTextFieldTests: XCTestCase {
     }
 
     func testPhoneNumberProperty() {
-        let textField = PhoneNumberTextField(withPhoneNumberKit: phoneNumberKit)
+        let textField = PhoneNumberTextField(utility: utility)
         textField.partialFormatter.defaultRegion = "US"
         textField.text = "4125551212"
         XCTAssertNotNil(textField.phoneNumber)
@@ -51,7 +51,7 @@ final class PhoneNumberTextFieldTests: XCTestCase {
     }
 
     func testUSPhoneNumberWithFlag() {
-        let textField = PhoneNumberTextField(withPhoneNumberKit: phoneNumberKit)
+        let textField = PhoneNumberTextField(utility: utility)
         textField.partialFormatter.defaultRegion = "US"
         textField.withFlag = true
         textField.text = "4125551212"
@@ -60,7 +60,7 @@ final class PhoneNumberTextFieldTests: XCTestCase {
     }
 
     func testNonUSPhoneNumberWithFlag() {
-        let textField = PhoneNumberTextField(withPhoneNumberKit: phoneNumberKit)
+        let textField = PhoneNumberTextField(utility: utility)
         textField.partialFormatter.defaultRegion = "US"
         textField.withFlag = true
         textField.text = "5872170177"

--- a/PhoneNumberKitTests/PhoneNumberUtilityParsingTests.swift
+++ b/PhoneNumberKitTests/PhoneNumberUtilityParsingTests.swift
@@ -11,154 +11,154 @@ import Foundation
 @testable import PhoneNumberKit
 import XCTest
 
-final class PhoneNumberKitParsingTests: XCTestCase {
-    private var phoneNumberKit: PhoneNumberKit!
+final class PhoneNumberUtilityParsingTests: XCTestCase {
+    private var sut: PhoneNumberUtility!
 
     override func setUp() {
         super.setUp()
-        phoneNumberKit = PhoneNumberKit()
+        sut = PhoneNumberUtility()
     }
 
     override func tearDown() {
-        phoneNumberKit = nil
+        sut = nil
         super.tearDown()
     }
 
     func testFailingNumber() {
-        XCTAssertThrowsError(try self.phoneNumberKit.parse("+5491187654321 ABC123", withRegion: "AR")) { error in
+        XCTAssertThrowsError(try self.sut.parse("+5491187654321 ABC123", withRegion: "AR")) { error in
             XCTAssertEqual(error as? PhoneNumberError, .invalidNumber)
         }
     }
 
     func testUSNumberNoPrefix() throws {
-        let phoneNumber1 = try phoneNumberKit.parse("650 253 0000", withRegion: "US")
-        let phoneNumberInternationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .international, withPrefix: false)
+        let phoneNumber1 = try sut.parse("650 253 0000", withRegion: "US")
+        let phoneNumberInternationalFormat1 = self.sut.format(phoneNumber1, toType: .international, withPrefix: false)
         XCTAssertEqual(phoneNumberInternationalFormat1, "650-253-0000")
-        let phoneNumberNationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .national, withPrefix: false)
+        let phoneNumberNationalFormat1 = self.sut.format(phoneNumber1, toType: .national, withPrefix: false)
         XCTAssertEqual(phoneNumberNationalFormat1, "(650) 253-0000")
-        let phoneNumberE164Format1 = self.phoneNumberKit.format(phoneNumber1, toType: .e164, withPrefix: false)
+        let phoneNumberE164Format1 = self.sut.format(phoneNumber1, toType: .e164, withPrefix: false)
         XCTAssertEqual(phoneNumberE164Format1, "6502530000")
 
-        let phoneNumber2 = try phoneNumberKit.parse("800 253 0000", withRegion: "US")
-        let phoneNumberInternationalFormat2 = self.phoneNumberKit.format(phoneNumber2, toType: .international, withPrefix: false)
+        let phoneNumber2 = try sut.parse("800 253 0000", withRegion: "US")
+        let phoneNumberInternationalFormat2 = self.sut.format(phoneNumber2, toType: .international, withPrefix: false)
         XCTAssertEqual(phoneNumberInternationalFormat2, "800-253-0000")
-        let phoneNumberNationalFormat2 = self.phoneNumberKit.format(phoneNumber2, toType: .national, withPrefix: false)
+        let phoneNumberNationalFormat2 = self.sut.format(phoneNumber2, toType: .national, withPrefix: false)
         XCTAssertEqual(phoneNumberNationalFormat2, "(800) 253-0000")
-        let phoneNumberE164Format2 = self.phoneNumberKit.format(phoneNumber2, toType: .e164, withPrefix: false)
+        let phoneNumberE164Format2 = self.sut.format(phoneNumber2, toType: .e164, withPrefix: false)
         XCTAssertEqual(phoneNumberE164Format2, "8002530000")
     }
 
     func testUSNumber() throws {
-        let phoneNumber1 = try phoneNumberKit.parse("650 253 0000", withRegion: "US")
-        let phoneNumberInternationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .international)
+        let phoneNumber1 = try sut.parse("650 253 0000", withRegion: "US")
+        let phoneNumberInternationalFormat1 = self.sut.format(phoneNumber1, toType: .international)
         XCTAssertEqual(phoneNumberInternationalFormat1, "+1 650-253-0000")
-        let phoneNumberNationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .national)
+        let phoneNumberNationalFormat1 = self.sut.format(phoneNumber1, toType: .national)
         XCTAssertEqual(phoneNumberNationalFormat1, "(650) 253-0000")
-        let phoneNumberE164Format1 = self.phoneNumberKit.format(phoneNumber1, toType: .e164)
+        let phoneNumberE164Format1 = self.sut.format(phoneNumber1, toType: .e164)
         XCTAssertEqual(phoneNumberE164Format1, "+16502530000")
 
-        let phoneNumber2 = try phoneNumberKit.parse("800 253 0000", withRegion: "US")
-        let phoneNumberInternationalFormat2 = self.phoneNumberKit.format(phoneNumber2, toType: .international)
+        let phoneNumber2 = try sut.parse("800 253 0000", withRegion: "US")
+        let phoneNumberInternationalFormat2 = self.sut.format(phoneNumber2, toType: .international)
         XCTAssertEqual(phoneNumberInternationalFormat2, "+1 800-253-0000")
-        let phoneNumberNationalFormat2 = self.phoneNumberKit.format(phoneNumber2, toType: .national)
+        let phoneNumberNationalFormat2 = self.sut.format(phoneNumber2, toType: .national)
         XCTAssertEqual(phoneNumberNationalFormat2, "(800) 253-0000")
-        let phoneNumberE164Format2 = self.phoneNumberKit.format(phoneNumber2, toType: .e164)
+        let phoneNumberE164Format2 = self.sut.format(phoneNumber2, toType: .e164)
         XCTAssertEqual(phoneNumberE164Format2, "+18002530000")
 
-        let phoneNumber3 = try phoneNumberKit.parse("900 253 0000", withRegion: "US")
-        let phoneNumberInternationalFormat3 = self.phoneNumberKit.format(phoneNumber3, toType: .international)
+        let phoneNumber3 = try sut.parse("900 253 0000", withRegion: "US")
+        let phoneNumberInternationalFormat3 = self.sut.format(phoneNumber3, toType: .international)
         XCTAssertEqual(phoneNumberInternationalFormat3, "+1 900-253-0000")
-        let phoneNumberNationalFormat3 = self.phoneNumberKit.format(phoneNumber3, toType: .national)
+        let phoneNumberNationalFormat3 = self.sut.format(phoneNumber3, toType: .national)
         XCTAssertEqual(phoneNumberNationalFormat3, "(900) 253-0000")
-        let phoneNumberE164Format3 = self.phoneNumberKit.format(phoneNumber3, toType: .e164)
+        let phoneNumberE164Format3 = self.sut.format(phoneNumber3, toType: .e164)
         XCTAssertEqual(phoneNumberE164Format3, "+19002530000")
     }
 
     func testBSNumber() throws {
-        let phoneNumber1 = try phoneNumberKit.parse("242 365 1234", withRegion: "BS")
-        let phoneNumberInternationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .international)
+        let phoneNumber1 = try sut.parse("242 365 1234", withRegion: "BS")
+        let phoneNumberInternationalFormat1 = self.sut.format(phoneNumber1, toType: .international)
         XCTAssertEqual(phoneNumberInternationalFormat1, "+1 242-365-1234")
-        let phoneNumberNationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .national)
+        let phoneNumberNationalFormat1 = self.sut.format(phoneNumber1, toType: .national)
         XCTAssertEqual(phoneNumberNationalFormat1, "(242) 365-1234")
-        let phoneNumberE164Format1 = self.phoneNumberKit.format(phoneNumber1, toType: .e164)
+        let phoneNumberE164Format1 = self.sut.format(phoneNumber1, toType: .e164)
         XCTAssertEqual(phoneNumberE164Format1, "+12423651234")
     }
 
     func testGBNumber() throws {
-        let phoneNumber1 = try phoneNumberKit.parse("(020) 7031 3000", withRegion: "GB")
-        let phoneNumberInternationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .international)
+        let phoneNumber1 = try sut.parse("(020) 7031 3000", withRegion: "GB")
+        let phoneNumberInternationalFormat1 = self.sut.format(phoneNumber1, toType: .international)
         XCTAssertEqual(phoneNumberInternationalFormat1, "+44 20 7031 3000")
-        let phoneNumberNationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .national)
+        let phoneNumberNationalFormat1 = self.sut.format(phoneNumber1, toType: .national)
         XCTAssertEqual(phoneNumberNationalFormat1, "020 7031 3000")
-        let phoneNumberE164Format1 = self.phoneNumberKit.format(phoneNumber1, toType: .e164)
+        let phoneNumberE164Format1 = self.sut.format(phoneNumber1, toType: .e164)
         XCTAssertEqual(phoneNumberE164Format1, "+442070313000")
 
-        let phoneNumber2 = try phoneNumberKit.parse("(07912) 345 678", withRegion: "GB")
-        let phoneNumberInternationalFormat2 = self.phoneNumberKit.format(phoneNumber2, toType: .international)
+        let phoneNumber2 = try sut.parse("(07912) 345 678", withRegion: "GB")
+        let phoneNumberInternationalFormat2 = self.sut.format(phoneNumber2, toType: .international)
         XCTAssertEqual(phoneNumberInternationalFormat2, "+44 7912 345678")
-        let phoneNumberNationalFormat2 = self.phoneNumberKit.format(phoneNumber2, toType: .national)
+        let phoneNumberNationalFormat2 = self.sut.format(phoneNumber2, toType: .national)
         XCTAssertEqual(phoneNumberNationalFormat2, "07912 345678")
-        let phoneNumberE164Format2 = self.phoneNumberKit.format(phoneNumber2, toType: .e164)
+        let phoneNumberE164Format2 = self.sut.format(phoneNumber2, toType: .e164)
         XCTAssertEqual(phoneNumberE164Format2, "+447912345678")
     }
 
     func testDENumber() throws {
-        let phoneNumber1 = try phoneNumberKit.parse("0291 12345678", withRegion: "DE")
-        let phoneNumberInternationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .international)
+        let phoneNumber1 = try sut.parse("0291 12345678", withRegion: "DE")
+        let phoneNumberInternationalFormat1 = self.sut.format(phoneNumber1, toType: .international)
         XCTAssertEqual(phoneNumberInternationalFormat1, "+49 291 12345678")
-        let phoneNumberNationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .national)
+        let phoneNumberNationalFormat1 = self.sut.format(phoneNumber1, toType: .national)
         XCTAssertEqual(phoneNumberNationalFormat1, "0291 12345678")
-        let phoneNumberE164Format1 = self.phoneNumberKit.format(phoneNumber1, toType: .e164)
+        let phoneNumberE164Format1 = self.sut.format(phoneNumber1, toType: .e164)
         XCTAssertEqual(phoneNumberE164Format1, "+4929112345678")
 
-        let phoneNumber2 = try phoneNumberKit.parse("04134 1234", withRegion: "DE")
-        let phoneNumberInternationalFormat2 = self.phoneNumberKit.format(phoneNumber2, toType: .international)
+        let phoneNumber2 = try sut.parse("04134 1234", withRegion: "DE")
+        let phoneNumberInternationalFormat2 = self.sut.format(phoneNumber2, toType: .international)
         XCTAssertEqual(phoneNumberInternationalFormat2, "+49 4134 1234")
-        let phoneNumberNationalFormat2 = self.phoneNumberKit.format(phoneNumber2, toType: .national)
+        let phoneNumberNationalFormat2 = self.sut.format(phoneNumber2, toType: .national)
         XCTAssertEqual(phoneNumberNationalFormat2, "04134 1234")
-        let phoneNumberE164Format2 = self.phoneNumberKit.format(phoneNumber2, toType: .e164)
+        let phoneNumberE164Format2 = self.sut.format(phoneNumber2, toType: .e164)
         XCTAssertEqual(phoneNumberE164Format2, "+4941341234")
 
-        let phoneNumber3 = try phoneNumberKit.parse("+49 8021 2345", withRegion: "DE")
-        let phoneNumberInternationalFormat3 = self.phoneNumberKit.format(phoneNumber3, toType: .international)
+        let phoneNumber3 = try sut.parse("+49 8021 2345", withRegion: "DE")
+        let phoneNumberInternationalFormat3 = self.sut.format(phoneNumber3, toType: .international)
         XCTAssertEqual(phoneNumberInternationalFormat3, "+49 8021 2345")
-        let phoneNumberNationalFormat3 = self.phoneNumberKit.format(phoneNumber3, toType: .national)
+        let phoneNumberNationalFormat3 = self.sut.format(phoneNumber3, toType: .national)
         XCTAssertEqual(phoneNumberNationalFormat3, "08021 2345")
-        let phoneNumberE164Format3 = self.phoneNumberKit.format(phoneNumber3, toType: .e164)
+        let phoneNumberE164Format3 = self.sut.format(phoneNumber3, toType: .e164)
         XCTAssertEqual(phoneNumberE164Format3, "+4980212345")
     }
 
     func testITNumber() throws {
-        let phoneNumber1 = try phoneNumberKit.parse("02 3661 8300", withRegion: "IT")
+        let phoneNumber1 = try sut.parse("02 3661 8300", withRegion: "IT")
         XCTAssertNotNil(phoneNumber1)
-        let phoneNumberInternationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .international)
+        let phoneNumberInternationalFormat1 = self.sut.format(phoneNumber1, toType: .international)
         XCTAssertEqual(phoneNumberInternationalFormat1, "+39 02 3661 8300")
-        let phoneNumberNationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .national)
+        let phoneNumberNationalFormat1 = self.sut.format(phoneNumber1, toType: .national)
         XCTAssertEqual(phoneNumberNationalFormat1, "02 3661 8300")
-        let phoneNumberE164Format1 = self.phoneNumberKit.format(phoneNumber1, toType: .e164)
+        let phoneNumberE164Format1 = self.sut.format(phoneNumber1, toType: .e164)
         XCTAssertEqual(phoneNumberE164Format1, "+390236618300")
     }
 
     func testAUNumber() throws {
-        let phoneNumber1 = try phoneNumberKit.parse("02 3661 8300", withRegion: "AU")
-        let phoneNumberInternationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .international)
+        let phoneNumber1 = try sut.parse("02 3661 8300", withRegion: "AU")
+        let phoneNumberInternationalFormat1 = self.sut.format(phoneNumber1, toType: .international)
         XCTAssertEqual(phoneNumberInternationalFormat1, "+61 2 3661 8300")
-        let phoneNumberNationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .national)
+        let phoneNumberNationalFormat1 = self.sut.format(phoneNumber1, toType: .national)
         XCTAssertEqual(phoneNumberNationalFormat1, "(02) 3661 8300")
-        let phoneNumberE164Format1 = self.phoneNumberKit.format(phoneNumber1, toType: .e164)
+        let phoneNumberE164Format1 = self.sut.format(phoneNumber1, toType: .e164)
         XCTAssertEqual(phoneNumberE164Format1, "+61236618300")
 
-        let phoneNumber2 = try phoneNumberKit.parse("+61 1800 123 456", withRegion: "AU")
-        let phoneNumberInternationalFormat2 = self.phoneNumberKit.format(phoneNumber2, toType: .international)
+        let phoneNumber2 = try sut.parse("+61 1800 123 456", withRegion: "AU")
+        let phoneNumberInternationalFormat2 = self.sut.format(phoneNumber2, toType: .international)
         XCTAssertEqual(phoneNumberInternationalFormat2, "+61 1800 123 456")
-        let phoneNumberNationalFormat2 = self.phoneNumberKit.format(phoneNumber2, toType: .national)
+        let phoneNumberNationalFormat2 = self.sut.format(phoneNumber2, toType: .national)
         XCTAssertEqual(phoneNumberNationalFormat2, "1800 123 456")
-        let phoneNumberE164Format2 = self.phoneNumberKit.format(phoneNumber2, toType: .e164)
+        let phoneNumberE164Format2 = self.sut.format(phoneNumber2, toType: .e164)
         XCTAssertEqual(phoneNumberE164Format2, "+611800123456")
     }
 
     func testAllExampleNumbers() {
-        let metaDataArray = self.phoneNumberKit.metadataManager.territories.filter { $0.codeID.count == 2 }
+        let metaDataArray = self.sut.metadataManager.territories.filter { $0.codeID.count == 2 }
         for metadata in metaDataArray {
             let codeID = metadata.codeID
             let metadataWithTypes: [(MetadataPhoneNumberDesc?, PhoneNumberType?)] = [
@@ -178,7 +178,7 @@ final class PhoneNumberKitParsingTests: XCTestCase {
                 if let desc = record.0 {
                     if let exampleNumber = desc.exampleNumber {
                         do {
-                            let phoneNumber = try phoneNumberKit.parse(exampleNumber, withRegion: codeID)
+                            let phoneNumber = try sut.parse(exampleNumber, withRegion: codeID)
                             XCTAssertNotNil(phoneNumber)
                             if let type = record.1 {
                                 if phoneNumber.type == .fixedOrMobile {
@@ -205,78 +205,78 @@ final class PhoneNumberKitParsingTests: XCTestCase {
     }
 
     func testUSTollFreeNumberType() throws {
-        let number = try phoneNumberKit.parse("8002345678", withRegion: "US")
+        let number = try sut.parse("8002345678", withRegion: "US")
         XCTAssertEqual(number.type, .tollFree)
     }
 
     func testBelizeTollFreeType() throws {
-        let number = try phoneNumberKit.parse("08001234123", withRegion: "BZ")
+        let number = try sut.parse("08001234123", withRegion: "BZ")
         XCTAssertEqual(number.type, .tollFree)
     }
 
     func testItalyFixedLineType() throws {
-        let number = try phoneNumberKit.parse("0669812345", withRegion: "IT")
+        let number = try sut.parse("0669812345", withRegion: "IT")
         XCTAssertEqual(number.type, .fixedLine)
     }
 
     func testMaldivesMobileNumber() throws {
-        let number = try phoneNumberKit.parse("7812345", withRegion: "MV")
+        let number = try sut.parse("7812345", withRegion: "MV")
         XCTAssertEqual(number.type, .mobile)
     }
 
     func testZimbabweVoipType() throws {
-        let number = try phoneNumberKit.parse("8686123456", withRegion: "ZW")
+        let number = try sut.parse("8686123456", withRegion: "ZW")
         XCTAssertEqual(number.type, .voip)
     }
 
     func testAntiguaPagerNumberType() throws {
-        let number = try phoneNumberKit.parse("12684061234", withRegion: "US")
+        let number = try sut.parse("12684061234", withRegion: "US")
         XCTAssertEqual(number.type, .pager)
     }
 
     func testFranceMobileNumberType() throws {
-        let number = try phoneNumberKit.parse("+33 612-345-678")
+        let number = try sut.parse("+33 612-345-678")
         XCTAssertEqual(number.type, .mobile)
     }
 
     func testAENumberWithHinduArabicNumerals() throws {
-        let phoneNumber1 = try phoneNumberKit.parse("+٩٧١٥٠٠٥٠٠٥٥٠", withRegion: "AE")
-        let phoneNumberInternationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .international)
+        let phoneNumber1 = try sut.parse("+٩٧١٥٠٠٥٠٠٥٥٠", withRegion: "AE")
+        let phoneNumberInternationalFormat1 = self.sut.format(phoneNumber1, toType: .international)
         XCTAssertEqual(phoneNumberInternationalFormat1, "+971 50 050 0550")
-        let phoneNumberNationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .national)
+        let phoneNumberNationalFormat1 = self.sut.format(phoneNumber1, toType: .national)
         XCTAssertEqual(phoneNumberNationalFormat1, "050 050 0550")
-        let phoneNumberE164Format1 = self.phoneNumberKit.format(phoneNumber1, toType: .e164)
+        let phoneNumberE164Format1 = self.sut.format(phoneNumber1, toType: .e164)
         XCTAssertEqual(phoneNumberE164Format1, "+971500500550")
     }
 
     func testAENumberWithMixedHinduArabicNumerals() throws {
-        let phoneNumber1 = try phoneNumberKit.parse("+٩٧١5٠٠5٠٠55٠", withRegion: "AE")
-        let phoneNumberInternationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .international)
+        let phoneNumber1 = try sut.parse("+٩٧١5٠٠5٠٠55٠", withRegion: "AE")
+        let phoneNumberInternationalFormat1 = self.sut.format(phoneNumber1, toType: .international)
         XCTAssertEqual(phoneNumberInternationalFormat1, "+971 50 050 0550")
-        let phoneNumberNationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .national)
+        let phoneNumberNationalFormat1 = self.sut.format(phoneNumber1, toType: .national)
         XCTAssertEqual(phoneNumberNationalFormat1, "050 050 0550")
-        let phoneNumberE164Format1 = self.phoneNumberKit.format(phoneNumber1, toType: .e164)
+        let phoneNumberE164Format1 = self.sut.format(phoneNumber1, toType: .e164)
         XCTAssertEqual(phoneNumberE164Format1, "+971500500550")
     }
 
     func testAENumberWithEasternArabicNumerals() throws {
-        let phoneNumber1 = try phoneNumberKit.parse("+۹۷۱۵۰۰۵۰۰۵۵۰", withRegion: "AE")
+        let phoneNumber1 = try sut.parse("+۹۷۱۵۰۰۵۰۰۵۵۰", withRegion: "AE")
         XCTAssertNotNil(phoneNumber1)
-        let phoneNumberInternationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .international)
+        let phoneNumberInternationalFormat1 = self.sut.format(phoneNumber1, toType: .international)
         XCTAssertEqual(phoneNumberInternationalFormat1, "+971 50 050 0550")
-        let phoneNumberNationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .national)
+        let phoneNumberNationalFormat1 = self.sut.format(phoneNumber1, toType: .national)
         XCTAssertEqual(phoneNumberNationalFormat1, "050 050 0550")
-        let phoneNumberE164Format1 = self.phoneNumberKit.format(phoneNumber1, toType: .e164)
+        let phoneNumberE164Format1 = self.sut.format(phoneNumber1, toType: .e164)
         XCTAssertEqual(phoneNumberE164Format1, "+971500500550")
     }
 
     func testAENumberWithMixedEasternArabicNumerals() throws {
-        let phoneNumber1 = try phoneNumberKit.parse("+۹۷۱5۰۰5۰۰55۰", withRegion: "AE")
-        let phoneNumberInternationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .international)
+        let phoneNumber1 = try sut.parse("+۹۷۱5۰۰5۰۰55۰", withRegion: "AE")
+        let phoneNumberInternationalFormat1 = self.sut.format(phoneNumber1, toType: .international)
         XCTAssertEqual(phoneNumberInternationalFormat1, "+971 50 050 0550")
-        let phoneNumberNationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .national)
+        let phoneNumberNationalFormat1 = self.sut.format(phoneNumber1, toType: .national)
         XCTAssertEqual(phoneNumberNationalFormat1, "050 050 0550")
-        let phoneNumberE164Format1 = self.phoneNumberKit.format(phoneNumber1, toType: .e164)
+        let phoneNumberE164Format1 = self.sut.format(phoneNumber1, toType: .e164)
         XCTAssertEqual(phoneNumberE164Format1, "+971500500550")
     }
 
@@ -288,7 +288,7 @@ final class PhoneNumberKitParsingTests: XCTestCase {
         for _ in 0..<numberOfParses {
             numberArray.append("+5491187654321")
         }
-        _ = self.phoneNumberKit.parse(numberArray, withRegion: "AR", ignoreType: true)
+        _ = self.sut.parse(numberArray, withRegion: "AR", ignoreType: true)
         endTime = Date()
         let timeInterval = endTime.timeIntervalSince(startTime)
         print("time to parse \(numberOfParses) phone numbers, \(timeInterval) seconds")
@@ -300,7 +300,7 @@ final class PhoneNumberKitParsingTests: XCTestCase {
         let startTime = Date()
         var endTime = Date()
         for _ in 0..<numberOfParses {
-            _ = try? self.phoneNumberKit.parse("+5491187654321", ignoreType: true)
+            _ = try? self.sut.parse("+5491187654321", ignoreType: true)
         }
         endTime = Date()
         let timeInterval = endTime.timeIntervalSince(startTime)
@@ -316,7 +316,7 @@ final class PhoneNumberKitParsingTests: XCTestCase {
         for _ in 0..<numberOfParses {
             numberArray.append("+5491187654321")
         }
-        _ = self.phoneNumberKit.parse(numberArray, ignoreType: true)
+        _ = self.sut.parse(numberArray, ignoreType: true)
         endTime = Date()
         let timeInterval = endTime.timeIntervalSince(startTime)
         print("time to parse \(numberOfParses) phone numbers, \(timeInterval) seconds")
@@ -328,7 +328,7 @@ final class PhoneNumberKitParsingTests: XCTestCase {
         let startTime = Date()
         var endTime = Date()
         for _ in 0..<numberOfParses {
-            _ = try self.phoneNumberKit.parse("+5491187654321", ignoreType: true)
+            _ = try self.sut.parse("+5491187654321", ignoreType: true)
         }
         endTime = Date()
         let timeInterval = endTime.timeIntervalSince(startTime)
@@ -344,7 +344,7 @@ final class PhoneNumberKitParsingTests: XCTestCase {
         for _ in 0..<numberOfParses {
             numberArray.append("+5491187654321")
         }
-        let phoneNumbers = self.phoneNumberKit.parseManager.parseMultiple(numberArray, withRegion: "AR", ignoreType: true)
+        let phoneNumbers = self.sut.parseManager.parseMultiple(numberArray, withRegion: "AR", ignoreType: true)
         XCTAssertTrue(phoneNumbers.count == numberOfParses)
         endTime = Date()
         let timeInterval = endTime.timeIntervalSince(startTime)
@@ -353,33 +353,33 @@ final class PhoneNumberKitParsingTests: XCTestCase {
     }
 
     func testUANumber() throws {
-        let phoneNumber1 = try phoneNumberKit.parse("501887766", withRegion: "UA")
+        let phoneNumber1 = try sut.parse("501887766", withRegion: "UA")
         XCTAssertNotNil(phoneNumber1)
-        let phoneNumberInternationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .international)
+        let phoneNumberInternationalFormat1 = self.sut.format(phoneNumber1, toType: .international)
         XCTAssertTrue(phoneNumberInternationalFormat1 == "+380 50 188 7766")
-        let phoneNumberNationalFormat1 = self.phoneNumberKit.format(phoneNumber1, toType: .national)
+        let phoneNumberNationalFormat1 = self.sut.format(phoneNumber1, toType: .national)
         XCTAssertTrue(phoneNumberNationalFormat1 == "050 188 7766")
-        let phoneNumberE164Format1 = self.phoneNumberKit.format(phoneNumber1, toType: .e164)
+        let phoneNumberE164Format1 = self.sut.format(phoneNumber1, toType: .e164)
         XCTAssertTrue(phoneNumberE164Format1 == "+380501887766")
 
-        let phoneNumber2 = try phoneNumberKit.parse("050 188 7766", withRegion: "UA")
+        let phoneNumber2 = try sut.parse("050 188 7766", withRegion: "UA")
         XCTAssertNotNil(phoneNumber2)
-        let phoneNumberInternationalFormat2 = self.phoneNumberKit.format(phoneNumber2, toType: .international)
+        let phoneNumberInternationalFormat2 = self.sut.format(phoneNumber2, toType: .international)
         XCTAssertTrue(phoneNumberInternationalFormat2 == "+380 50 188 7766")
-        let phoneNumberNationalFormat2 = self.phoneNumberKit.format(phoneNumber2, toType: .national)
+        let phoneNumberNationalFormat2 = self.sut.format(phoneNumber2, toType: .national)
         XCTAssertTrue(phoneNumberNationalFormat2 == "050 188 7766")
-        let phoneNumberE164Format2 = self.phoneNumberKit.format(phoneNumber2, toType: .e164)
+        let phoneNumberE164Format2 = self.sut.format(phoneNumber2, toType: .e164)
         XCTAssertTrue(phoneNumberE164Format2 == "+380501887766")
     }
 
     func testExtensionWithCommaParsing() throws {
-        let number = try phoneNumberKit.parse("+33 612-345-678,22")
+        let number = try sut.parse("+33 612-345-678,22")
         XCTAssertEqual(number.type, .mobile)
         XCTAssertEqual(number.numberExtension, "22")
     }
 
     func testExtensionWithSemiColonParsing() throws {
-        let number = try phoneNumberKit.parse("+33 612-345-678;22")
+        let number = try sut.parse("+33 612-345-678;22")
         XCTAssertEqual(number.type, .mobile)
         XCTAssertEqual(number.numberExtension, "22")
     }
@@ -387,14 +387,14 @@ final class PhoneNumberKitParsingTests: XCTestCase {
     func testNonAmbiguousPhoneNumber() {
         // This phone number was incorrectly identified as ambiguous.
         let address = "+1 345 916 1234"
-        try XCTAssertNotNil(phoneNumberKit.parse(address, withRegion: "JM"))
+        try XCTAssertNotNil(sut.parse(address, withRegion: "JM"))
     }
 
     func testRegionCountryCodeConflict() {
-        XCTAssertThrowsError(try phoneNumberKit.parse("212-2344", withRegion: "US")) { error in
+        XCTAssertThrowsError(try sut.parse("212-2344", withRegion: "US")) { error in
             XCTAssertEqual(error as? PhoneNumberError, .invalidNumber)
         }
-        XCTAssertThrowsError(try phoneNumberKit.parse("352-2344", withRegion: "US")) { error in
+        XCTAssertThrowsError(try sut.parse("352-2344", withRegion: "US")) { error in
             XCTAssertEqual(error as? PhoneNumberError, .invalidNumber)
         }
     }

--- a/PhoneNumberKitTests/PhoneNumberUtilityTests.swift
+++ b/PhoneNumberKitTests/PhoneNumberUtilityTests.swift
@@ -9,36 +9,36 @@
 @testable import PhoneNumberKit
 import XCTest
 
-final class PhoneNumberKitTests: XCTestCase {
-    private var phoneNumberKit: PhoneNumberKit!
+final class PhoneNumberUtilityTests: XCTestCase {
+    private var sut: PhoneNumberUtility!
 
     override func setUp() {
         super.setUp()
-        phoneNumberKit = PhoneNumberKit()
+        sut = PhoneNumberUtility()
     }
 
     override func tearDown() {
-        phoneNumberKit = nil
+        sut = nil
         super.tearDown()
     }
 
     func testMetadataMainCountryFetch() {
-        let countryMetadata = self.phoneNumberKit.metadataManager.mainTerritory(forCode: 1)
+        let countryMetadata = self.sut.metadataManager.mainTerritory(forCode: 1)
         XCTAssertEqual(countryMetadata?.codeID, "US")
     }
 
     func testMetadataMainCountryFunction() {
-        let countryName = self.phoneNumberKit.mainCountry(forCode: 1)!
+        let countryName = self.sut.mainCountry(forCode: 1)!
         XCTAssertEqual(countryName, "US")
-        let invalidCountry = self.phoneNumberKit.mainCountry(forCode: 992_322)
+        let invalidCountry = self.sut.mainCountry(forCode: 992_322)
         XCTAssertNil(invalidCountry)
     }
 
     // Invalid american number, GitHub issue #8 by j-pk
     func testInvalidNumberE() {
         do {
-            let phoneNumber = try phoneNumberKit.parse("202 00e 0000", withRegion: "US")
-            print(self.phoneNumberKit.format(phoneNumber, toType: .e164))
+            let phoneNumber = try sut.parse("202 00e 0000", withRegion: "US")
+            print(self.sut.format(phoneNumber, toType: .e164))
             XCTFail()
         } catch {
             XCTAssert(true)
@@ -48,8 +48,8 @@ final class PhoneNumberKitTests: XCTestCase {
     // Valid indian number, GitHub issue #235
     func testValidNumber6() {
         do {
-            let phoneNumber = try phoneNumberKit.parse("6297062979", withRegion: "IN")
-            print(self.phoneNumberKit.format(phoneNumber, toType: .e164))
+            let phoneNumber = try sut.parse("6297062979", withRegion: "IN")
+            print(self.sut.format(phoneNumber, toType: .e164))
             XCTAssert(true)
         } catch {
             XCTFail()
@@ -58,15 +58,15 @@ final class PhoneNumberKitTests: XCTestCase {
 
     // Bool checker, GitHub issue #325
     func testValidNumberBool() {
-        XCTAssert(phoneNumberKit.isValidPhoneNumber("6297062979", withRegion: "IN"))
-        XCTAssertFalse(phoneNumberKit.isValidPhoneNumber("202 00e 0000", withRegion: "US"))
+        XCTAssert(sut.isValidPhoneNumber("6297062979", withRegion: "IN"))
+        XCTAssertFalse(sut.isValidPhoneNumber("202 00e 0000", withRegion: "US"))
     }
 
     // Invalid american number, GitHub issue #9 by lobodin
     func testAmbiguousFixedOrMobileNumber() {
         do {
-            let phoneNumber = try phoneNumberKit.parse("+16307792428", withRegion: "US")
-            print(self.phoneNumberKit.format(phoneNumber, toType: .e164))
+            let phoneNumber = try sut.parse("+16307792428", withRegion: "US")
+            print(self.sut.format(phoneNumber, toType: .e164))
             let type = phoneNumber.type
             XCTAssertEqual(type, PhoneNumberType.fixedOrMobile)
         } catch {
@@ -79,8 +79,8 @@ final class PhoneNumberKitTests: XCTestCase {
         do {
             // libphonenumber reports this number as invalid
             // and it's true, this is a French mobile number combined with the GB region
-            let phoneNumber = try phoneNumberKit.parse("+44629996885")
-            print(self.phoneNumberKit.format(phoneNumber, toType: .e164))
+            let phoneNumber = try sut.parse("+44629996885")
+            print(self.sut.format(phoneNumber, toType: .e164))
             XCTFail()
         } catch {
             XCTAssert(true)
@@ -92,8 +92,8 @@ final class PhoneNumberKitTests: XCTestCase {
         do {
             // libphonenumber reports this number as invalid
             // and it's true, this is a French mobile number combined with the BE region
-            let phoneNumber = try phoneNumberKit.parse("+32910853865")
-            print(self.phoneNumberKit.format(phoneNumber, toType: .e164))
+            let phoneNumber = try sut.parse("+32910853865")
+            print(self.sut.format(phoneNumber, toType: .e164))
             XCTFail()
         } catch {
             XCTAssert(true)
@@ -105,8 +105,8 @@ final class PhoneNumberKitTests: XCTestCase {
         do {
             // libphonenumber reports this number as invalid
             // and it's true, this is a French mobile number combined with the DZ region
-            let phoneNumber = try phoneNumberKit.parse("+21373344376")
-            print(self.phoneNumberKit.format(phoneNumber, toType: .e164))
+            let phoneNumber = try sut.parse("+21373344376")
+            print(self.sut.format(phoneNumber, toType: .e164))
             XCTFail()
         } catch {
             XCTAssert(true)
@@ -118,8 +118,8 @@ final class PhoneNumberKitTests: XCTestCase {
         do {
             // libphonenumber reports this number as invalid
             // and it's true, this is a French mobile number combined with the CN region
-            let phoneNumber = try phoneNumberKit.parse("+861500376135")
-            print(self.phoneNumberKit.format(phoneNumber, toType: .e164))
+            let phoneNumber = try sut.parse("+861500376135")
+            print(self.sut.format(phoneNumber, toType: .e164))
             XCTFail()
         } catch {
             XCTAssert(true)
@@ -131,8 +131,8 @@ final class PhoneNumberKitTests: XCTestCase {
         do {
             // libphonenumber reports this number as invalid
             // and it's true, this is a French mobile number combined with the IT region
-            let phoneNumber = try phoneNumberKit.parse("+390762613915")
-            print(self.phoneNumberKit.format(phoneNumber, toType: .e164))
+            let phoneNumber = try sut.parse("+390762613915")
+            print(self.sut.format(phoneNumber, toType: .e164))
             XCTFail()
         } catch {
             XCTAssert(true)
@@ -144,8 +144,8 @@ final class PhoneNumberKitTests: XCTestCase {
         do {
             // libphonenumber reports this number as invalid
             // and it's true, this is a French mobile number combined with the ES region
-            let phoneNumber = try phoneNumberKit.parse("+34312431110")
-            print(self.phoneNumberKit.format(phoneNumber, toType: .e164))
+            let phoneNumber = try sut.parse("+34312431110")
+            print(self.sut.format(phoneNumber, toType: .e164))
             XCTFail()
         } catch {
             XCTAssert(true)
@@ -156,7 +156,7 @@ final class PhoneNumberKitTests: XCTestCase {
     func testItalianLeadingZero() {
         let testNumber = "+39 0549555555"
         do {
-            let phoneNumber = try phoneNumberKit.parse(testNumber)
+            let phoneNumber = try sut.parse(testNumber)
 //            XCTAssertEqual(phoneNumber.toInternational(), testNumber)
             XCTAssertEqual(phoneNumber.countryCode, 39)
             XCTAssertEqual(phoneNumber.nationalNumber, 549_555_555)
@@ -170,7 +170,7 @@ final class PhoneNumberKitTests: XCTestCase {
     func testNumberWithExtension() {
         let testNumber = "+33-689-5-5555-5 ext. 84"
         do {
-            let phoneNumber = try phoneNumberKit.parse(testNumber)
+            let phoneNumber = try sut.parse(testNumber)
             XCTAssertEqual(phoneNumber.countryCode, 33)
             XCTAssertEqual(phoneNumber.numberExtension, "84")
             XCTAssertEqual(phoneNumber.nationalNumber, 689_555_555)
@@ -184,7 +184,7 @@ final class PhoneNumberKitTests: XCTestCase {
     func testAlternativeNumberWithExtension() {
         let testNumber = "2129316760 x28"
         do {
-            let phoneNumber = try phoneNumberKit.parse(testNumber, withRegion: "US", ignoreType: false)
+            let phoneNumber = try sut.parse(testNumber, withRegion: "US", ignoreType: false)
             XCTAssertEqual(phoneNumber.countryCode, 1)
             XCTAssertEqual(phoneNumber.numberExtension, "28")
             XCTAssertEqual(phoneNumber.nationalNumber, 2_129_316_760)
@@ -198,9 +198,9 @@ final class PhoneNumberKitTests: XCTestCase {
     func testValidNumberWithPlusNoWhiteSpace() {
         let testNumber = "+33689555555"
         do {
-            let phoneNumber = try phoneNumberKit.parse(testNumber)
-            XCTAssertEqual(self.phoneNumberKit.format(phoneNumber, toType: .e164), testNumber)
-            XCTAssertEqual(self.phoneNumberKit.format(phoneNumber, toType: .international, withPrefix: false), "6 89 55 55 55")
+            let phoneNumber = try sut.parse(testNumber)
+            XCTAssertEqual(self.sut.format(phoneNumber, toType: .e164), testNumber)
+            XCTAssertEqual(self.sut.format(phoneNumber, toType: .international, withPrefix: false), "6 89 55 55 55")
             XCTAssertEqual(phoneNumber.countryCode, 33)
             XCTAssertEqual(phoneNumber.nationalNumber, 689_555_555)
             XCTAssertEqual(phoneNumber.leadingZero, false)
@@ -214,8 +214,8 @@ final class PhoneNumberKitTests: XCTestCase {
     func testValidNumberWithPlusWhiteSpace() {
         let testNumber = "+81 601 55-5-5 5 5"
         do {
-            let phoneNumber = try phoneNumberKit.parse(testNumber)
-            XCTAssertEqual(self.phoneNumberKit.format(phoneNumber, toType: .e164), "+81601555555")
+            let phoneNumber = try sut.parse(testNumber)
+            XCTAssertEqual(self.sut.format(phoneNumber, toType: .e164), "+81601555555")
             XCTAssertEqual(phoneNumber.countryCode, 81)
             XCTAssertEqual(phoneNumber.nationalNumber, 601_555_555)
             XCTAssertEqual(phoneNumber.leadingZero, false)
@@ -228,8 +228,8 @@ final class PhoneNumberKitTests: XCTestCase {
     func testValidNumberWithAmericanIDDNoWhiteSpace() {
         let testNumber = "011447739555555"
         do {
-            let phoneNumber = try phoneNumberKit.parse(testNumber, withRegion: "US")
-            XCTAssertEqual(self.phoneNumberKit.format(phoneNumber, toType: .e164), "+447739555555")
+            let phoneNumber = try sut.parse(testNumber, withRegion: "US")
+            XCTAssertEqual(self.sut.format(phoneNumber, toType: .e164), "+447739555555")
             XCTAssertEqual(phoneNumber.countryCode, 44)
             XCTAssertEqual(phoneNumber.nationalNumber, 7_739_555_555)
             XCTAssertEqual(phoneNumber.leadingZero, false)
@@ -242,8 +242,8 @@ final class PhoneNumberKitTests: XCTestCase {
     func testValidNumberWithAmericanIDDWhiteSpace() {
         let testNumber = "01155 11 9 6 555 55 55"
         do {
-            let phoneNumber = try phoneNumberKit.parse(testNumber, withRegion: "US")
-            XCTAssertEqual(self.phoneNumberKit.format(phoneNumber, toType: .e164), "+5511965555555")
+            let phoneNumber = try sut.parse(testNumber, withRegion: "US")
+            XCTAssertEqual(self.sut.format(phoneNumber, toType: .e164), "+5511965555555")
             XCTAssertEqual(phoneNumber.countryCode, 55)
             XCTAssertEqual(phoneNumber.nationalNumber, 11_965_555_555)
             XCTAssertEqual(phoneNumber.leadingZero, false)
@@ -256,8 +256,8 @@ final class PhoneNumberKitTests: XCTestCase {
     func testValidLocalNumberWithNoPrefixNoWhiteSpace() {
         let testNumber = "2015555555"
         do {
-            let phoneNumber = try phoneNumberKit.parse(testNumber, withRegion: "US")
-            XCTAssertEqual(self.phoneNumberKit.format(phoneNumber, toType: .e164), "+12015555555")
+            let phoneNumber = try sut.parse(testNumber, withRegion: "US")
+            XCTAssertEqual(self.sut.format(phoneNumber, toType: .e164), "+12015555555")
             XCTAssertEqual(phoneNumber.countryCode, 1)
             XCTAssertEqual(phoneNumber.nationalNumber, 2_015_555_555)
             XCTAssertEqual(phoneNumber.leadingZero, false)
@@ -270,8 +270,8 @@ final class PhoneNumberKitTests: XCTestCase {
     func testValidLocalNumberWithNoPrefixWhiteSpace() {
         let testNumber = "500-2-55-555-5"
         do {
-            let phoneNumber = try phoneNumberKit.parse(testNumber, withRegion: "US")
-            XCTAssertEqual(self.phoneNumberKit.format(phoneNumber, toType: .e164), "+15002555555")
+            let phoneNumber = try sut.parse(testNumber, withRegion: "US")
+            XCTAssertEqual(self.sut.format(phoneNumber, toType: .e164), "+15002555555")
             XCTAssertEqual(phoneNumber.countryCode, 1)
             XCTAssertEqual(phoneNumber.nationalNumber, 5_002_555_555)
             XCTAssertEqual(phoneNumber.leadingZero, false)
@@ -283,8 +283,8 @@ final class PhoneNumberKitTests: XCTestCase {
     func testValidAENumberWithHinduArabicNumerals() {
         let testNumber = "+٩٧١٥٠٠٥٠٠٥٥٠"
         do {
-            let phoneNumber = try phoneNumberKit.parse(testNumber, withRegion: "AE")
-            XCTAssertEqual(self.phoneNumberKit.format(phoneNumber, toType: .e164), "+971500500550")
+            let phoneNumber = try sut.parse(testNumber, withRegion: "AE")
+            XCTAssertEqual(self.sut.format(phoneNumber, toType: .e164), "+971500500550")
             XCTAssertEqual(phoneNumber.countryCode, 971)
             XCTAssertEqual(phoneNumber.nationalNumber, 500_500_550)
             XCTAssertEqual(phoneNumber.leadingZero, false)
@@ -296,8 +296,8 @@ final class PhoneNumberKitTests: XCTestCase {
     func testValidAENumberWithMixedHinduArabicNumerals() {
         let testNumber = "+٩٧١5٠٠5٠٠55٠"
         do {
-            let phoneNumber = try phoneNumberKit.parse(testNumber, withRegion: "AE")
-            XCTAssertEqual(self.phoneNumberKit.format(phoneNumber, toType: .e164), "+971500500550")
+            let phoneNumber = try sut.parse(testNumber, withRegion: "AE")
+            XCTAssertEqual(self.sut.format(phoneNumber, toType: .e164), "+971500500550")
             XCTAssertEqual(phoneNumber.countryCode, 971)
             XCTAssertEqual(phoneNumber.nationalNumber, 500_500_550)
             XCTAssertEqual(phoneNumber.leadingZero, false)
@@ -309,8 +309,8 @@ final class PhoneNumberKitTests: XCTestCase {
     func testValidAENumberWithEasternArabicNumerals() {
         let testNumber = "+۹۷۱۵۰۰۵۰۰۵۵۰"
         do {
-            let phoneNumber = try phoneNumberKit.parse(testNumber, withRegion: "AE")
-            XCTAssertEqual(self.phoneNumberKit.format(phoneNumber, toType: .e164), "+971500500550")
+            let phoneNumber = try sut.parse(testNumber, withRegion: "AE")
+            XCTAssertEqual(self.sut.format(phoneNumber, toType: .e164), "+971500500550")
             XCTAssertEqual(phoneNumber.countryCode, 971)
             XCTAssertEqual(phoneNumber.nationalNumber, 500_500_550)
             XCTAssertEqual(phoneNumber.leadingZero, false)
@@ -322,8 +322,8 @@ final class PhoneNumberKitTests: XCTestCase {
     func testValidAENumberWithMixedEasternArabicNumerals() {
         let testNumber = "+۹۷۱5۰۰5۰۰55۰"
         do {
-            let phoneNumber = try phoneNumberKit.parse(testNumber, withRegion: "AE")
-            XCTAssertEqual(self.phoneNumberKit.format(phoneNumber, toType: .e164), "+971500500550")
+            let phoneNumber = try sut.parse(testNumber, withRegion: "AE")
+            XCTAssertEqual(self.sut.format(phoneNumber, toType: .e164), "+971500500550")
             XCTAssertEqual(phoneNumber.countryCode, 971)
             XCTAssertEqual(phoneNumber.nationalNumber, 500_500_550)
             XCTAssertEqual(phoneNumber.leadingZero, false)
@@ -336,8 +336,8 @@ final class PhoneNumberKitTests: XCTestCase {
     func testInvalidNumberTooShort() {
         let testNumber = "+44 32"
         do {
-            let phoneNumber = try phoneNumberKit.parse(testNumber)
-            _ = self.phoneNumberKit.format(phoneNumber, toType: .e164)
+            let phoneNumber = try sut.parse(testNumber)
+            _ = self.sut.format(phoneNumber, toType: .e164)
             XCTFail()
         } catch {
             XCTAssert(true)
@@ -348,8 +348,8 @@ final class PhoneNumberKitTests: XCTestCase {
     func testInvalidNumberTooLong() {
         let testNumber = "+44 3243894723084732047023472"
         do {
-            let phoneNumber = try phoneNumberKit.parse(testNumber)
-            _ = self.phoneNumberKit.format(phoneNumber, toType: .e164)
+            let phoneNumber = try sut.parse(testNumber)
+            _ = self.sut.format(phoneNumber, toType: .e164)
             XCTFail()
         } catch {
             XCTAssert(true)
@@ -360,8 +360,8 @@ final class PhoneNumberKitTests: XCTestCase {
     func testInvalidNumberNotANumber() {
         let testNumber = "ae4c08c6-be33-40ef-a417-e5166e307b5e"
         do {
-            let phoneNumber = try phoneNumberKit.parse(testNumber)
-            _ = self.phoneNumberKit.format(phoneNumber, toType: .e164)
+            let phoneNumber = try sut.parse(testNumber)
+            _ = self.sut.format(phoneNumber, toType: .e164)
             XCTFail()
         } catch {
             XCTAssert(true)
@@ -370,64 +370,63 @@ final class PhoneNumberKitTests: XCTestCase {
 
     //  Invalid number invalid format
     func testInvalidNumberNotANumberInvalidFormat() {
-        XCTAssertThrowsError(try phoneNumberKit.parse("+33(02)689555555")) { error in
+        XCTAssertThrowsError(try sut.parse("+33(02)689555555")) { error in
             XCTAssertEqual(error as? PhoneNumberError, PhoneNumberError.invalidNumber)
         }
     }
 
     //  Test that metadata initiates correctly by checking all countries
     func testAllCountries() {
-        let allCountries = self.phoneNumberKit.allCountries()
+        let allCountries = self.sut.allCountries()
         XCTAssert(!allCountries.isEmpty)
     }
 
     //  Test code for country function -  valid country
     func testCodeForCountryValid() {
-        XCTAssertEqual(self.phoneNumberKit.countryCode(for: "FR"), 33)
+        XCTAssertEqual(self.sut.countryCode(for: "FR"), 33)
     }
 
     //  Test code for country function - invalid country
     func testCodeForCountryInvalid() {
-        XCTAssertEqual(self.phoneNumberKit.countryCode(for: "FOOBAR"), nil)
+        XCTAssertEqual(self.sut.countryCode(for: "FOOBAR"), nil)
     }
 
     //  Test countries for code function
     func testCountriesForCodeValid() {
-        XCTAssertEqual(self.phoneNumberKit.countries(withCode: 1)?.count, 25)
+        XCTAssertEqual(self.sut.countries(withCode: 1)?.count, 25)
     }
 
     //  Test countries for code function
     func testCountriesForCodeInvalid() {
-        let phoneNumberKit = PhoneNumberKit()
-        XCTAssertEqual(phoneNumberKit.countries(withCode: 424_242)?.count, nil)
+        XCTAssertEqual(self.sut.countries(withCode: 424_242)?.count, nil)
     }
 
     //  Test region code for number function
     func testGetRegionCode() {
-        guard let phoneNumber = try? phoneNumberKit.parse("+39 3123456789") else {
+        guard let phoneNumber = try? sut.parse("+39 3123456789") else {
             XCTFail()
             return
         }
-        XCTAssertEqual(self.phoneNumberKit.getRegionCode(of: phoneNumber), "IT")
+        XCTAssertEqual(self.sut.getRegionCode(of: phoneNumber), "IT")
     }
 
     // In the case of multiple
     // countries sharing a calling code, the one
     // indicated with "isMainCountryForCode" in the metadata should be first.
     func testGetRegionCodeForTollFreeFromUS() {
-        guard let phoneNumber = try? phoneNumberKit.parse("+1 888 579 4458") else {
+        guard let phoneNumber = try? sut.parse("+1 888 579 4458") else {
             XCTFail()
             return
         }
-        XCTAssertEqual(self.phoneNumberKit.getRegionCode(of: phoneNumber), "US")
+        XCTAssertEqual(self.sut.getRegionCode(of: phoneNumber), "US")
     }
 
     // RU number with KZ country code
     func testValidRUNumberWithKZRegion() {
         let testNumber = "+7 916 195 55 58"
         do {
-            let phoneNumber = try phoneNumberKit.parse(testNumber, withRegion: "KZ")
-            XCTAssertEqual(self.phoneNumberKit.format(phoneNumber, toType: .e164), "+79161955558")
+            let phoneNumber = try sut.parse(testNumber, withRegion: "KZ")
+            XCTAssertEqual(self.sut.format(phoneNumber, toType: .e164), "+79161955558")
             XCTAssertEqual(phoneNumber.countryCode, 7)
             XCTAssertEqual(phoneNumber.nationalNumber, 9_161_955_558)
             XCTAssertEqual(phoneNumber.leadingZero, false)
@@ -439,17 +438,17 @@ final class PhoneNumberKitTests: XCTestCase {
 
     func testValidKZNumbersWithInternationalPrefix() {
         let numbers = ["+7 (777)110-85-31", "+77777056982", "+7(701)977-75-05"]
-        numbers.forEach { XCTAssertTrue(phoneNumberKit.isValidPhoneNumber($0, withRegion: "KZ")) }
-        numbers.forEach { XCTAssertTrue(phoneNumberKit.isValidPhoneNumber($0)) }
-        numbers.forEach { XCTAssertTrue(phoneNumberKit.isValidPhoneNumber($0, withRegion: "RU")) }
+        numbers.forEach { XCTAssertTrue(sut.isValidPhoneNumber($0, withRegion: "KZ")) }
+        numbers.forEach { XCTAssertTrue(sut.isValidPhoneNumber($0)) }
+        numbers.forEach { XCTAssertTrue(sut.isValidPhoneNumber($0, withRegion: "RU")) }
     }
 
     func testValidKZNumbersWithoutInternationalPrefix() {
         let numbers = ["(777)110-85-31", "7777056982", "(701)977-75-05"]
-        numbers.forEach { XCTAssertTrue(phoneNumberKit.isValidPhoneNumber($0, withRegion: "KZ")) }
+        numbers.forEach { XCTAssertTrue(sut.isValidPhoneNumber($0, withRegion: "KZ")) }
         numbers.forEach {
             do {
-                let phoneNumber = try phoneNumberKit.parse($0, withRegion: "RU")
+                let phoneNumber = try sut.parse($0, withRegion: "RU")
                 XCTAssertEqual(phoneNumber.countryCode, 7)
                 XCTAssertEqual(phoneNumber.regionID, "KZ")
             } catch {
@@ -461,10 +460,10 @@ final class PhoneNumberKitTests: XCTestCase {
     func testValidCZNumbers() throws {
         let numbers = ["420734593819", "+420734593819", "734593819"]
         try numbers.forEach {
-            let phoneNumber = try phoneNumberKit.parse($0, withRegion: "CZ")
+            let phoneNumber = try sut.parse($0, withRegion: "CZ")
             XCTAssertNotNil(phoneNumber)
 
-            let formatted = phoneNumberKit.format(phoneNumber, toType: .e164)
+            let formatted = sut.format(phoneNumber, toType: .e164)
             XCTAssertEqual(formatted, "+420734593819")
         }
     }
@@ -472,10 +471,10 @@ final class PhoneNumberKitTests: XCTestCase {
     func testValidDENumbers() throws {
         let numbers = ["491713369876", "+491713369876", "01713369876", "1713369876"]
         try numbers.forEach {
-            let phoneNumber = try phoneNumberKit.parse($0, withRegion: "DE")
+            let phoneNumber = try sut.parse($0, withRegion: "DE")
             XCTAssertNotNil(phoneNumber)
 
-            let formatted = phoneNumberKit.format(phoneNumber, toType: .e164)
+            let formatted = sut.format(phoneNumber, toType: .e164)
             XCTAssertEqual(formatted, "+491713369876")
         }
     }

--- a/README.md
+++ b/README.md
@@ -29,20 +29,20 @@ Import PhoneNumberKit at the top of the Swift file that will interact with a pho
 import PhoneNumberKit
 ```
 
-All of your interactions with PhoneNumberKit happen through a PhoneNumberKit object. The first step you should take is to allocate one.
+All of your interactions with PhoneNumberKit happen through a PhoneNumberUtility object. The first step you should take is to allocate one.
 
-A PhoneNumberKit instance is relatively expensive to allocate (it parses the metadata and keeps it in memory for the object's lifecycle), you should try and make sure PhoneNumberKit is allocated once and deallocated when no longer needed.
+A PhoneNumberUtility instance is relatively expensive to allocate (it parses the metadata and keeps it in memory for the object's lifecycle), you should try and make sure PhoneNumberUtility is allocated once and deallocated when no longer needed.
 
 ```swift
-let phoneNumberKit = PhoneNumberKit()
+let phoneNumberUtility = PhoneNumberUtility()
 ```
 
 To parse a string, use the parse function. The region code is automatically computed but can be overridden if needed. PhoneNumberKit automatically does a hard type validation to ensure that the object created is valid, this can be quite costly performance-wise and can be turned off if needed.
 
 ```swift
 do {
-    let phoneNumber = try phoneNumberKit.parse("+33 6 89 017383")
-    let phoneNumberCustomDefaultRegion = try phoneNumberKit.parse("+44 20 7031 3000", withRegion: "GB", ignoreType: true)
+    let phoneNumber = try phoneNumberUtility.parse("+33 6 89 017383")
+    let phoneNumberCustomDefaultRegion = try phoneNumberUtility.parse("+44 20 7031 3000", withRegion: "GB", ignoreType: true)
 }
 catch {
     print("Generic parser error")
@@ -53,8 +53,8 @@ If you need to parse and validate a large amount of numbers at once, PhoneNumber
 
 ```swift
 let rawNumberArray = ["0291 12345678", "+49 291 12345678", "04134 1234", "09123 12345"]
-let phoneNumbers = phoneNumberKit.parse(rawNumberArray)
-let phoneNumbersCustomDefaultRegion = phoneNumberKit.parse(rawNumberArray, withRegion: "DE",  ignoreType: true)
+let phoneNumbers = phoneNumberUtility.parse(rawNumberArray)
+let phoneNumbersCustomDefaultRegion = phoneNumberUtility.parse(rawNumberArray, withRegion: "DE",  ignoreType: true)
 ```
 
 PhoneNumber objects are immutable Swift structs with the following properties:
@@ -70,9 +70,9 @@ phoneNumber.type // e.g Mobile or Fixed
 Formatting a PhoneNumber object into a string is also very easy
 
 ```swift
-phoneNumberKit.format(phoneNumber, toType: .e164) // +61236618300
-phoneNumberKit.format(phoneNumber, toType: .international) // +61 2 3661 8300
-phoneNumberKit.format(phoneNumber, toType: .national) // (02) 3661 8300
+phoneNumberUtility.format(phoneNumber, toType: .e164) // +61236618300
+phoneNumberUtility.format(phoneNumber, toType: .international) // +61 2 3661 8300
+phoneNumberUtility.format(phoneNumber, toType: .national) // (02) 3661 8300
 ```
 
 ## PhoneNumberTextField
@@ -108,8 +108,8 @@ PartialFormatter().formatPartial("+336895555") // +33 6 89 55 55
 You can also query countries for a dialing code or the dialing code for a given country
 
 ```swift
-phoneNumberKit.countries(withCode: 33)
-phoneNumberKit.countryCode(for: "FR")
+phoneNumberUtility.countries(withCode: 33)
+phoneNumberUtility.countryCode(for: "FR")
 ```
 
 ## Customize Country Picker
@@ -145,7 +145,7 @@ Please refer to `CountryCodePickerOptions` for more information about usage and 
 You can access the metadata powering PhoneNumberKit yourself, this enables you to program any behaviours as they may be implemented in PhoneNumberKit itself. It does mean you are exposed to the less polished interface of the underlying file format. If you program something you find useful please push it upstream!
 
 ```swift
-phoneNumberKit.metadata(for: "AU")?.mobile?.exampleNumber // 412345678
+phoneNumberUtility.metadata(for: "AU")?.mobile?.exampleNumber // 412345678
 ```
 
 ### [Preferred] Setting up with [Swift Package Manager](https://swiftpm.co/?query=PhoneNumberKit)

--- a/examples/PhoneBook/Sample/ViewController.swift
+++ b/examples/PhoneBook/Sample/ViewController.swift
@@ -12,7 +12,7 @@ import PhoneNumberKit
 import UIKit
 
 class ViewController: UIViewController, CNContactPickerDelegate {
-    let phoneNumberKit = PhoneNumberKit()
+    let phoneNumberUtility = PhoneNumberUtility()
 
     @IBOutlet var parsedNumberLabel: UILabel!
     @IBOutlet var parsedCountryCodeLabel: UILabel!
@@ -54,10 +54,10 @@ class ViewController: UIViewController, CNContactPickerDelegate {
 
     func parseNumber(_ number: String) {
         do {
-            let phoneNumber = try phoneNumberKit.parse(number, ignoreType: true)
-            self.parsedNumberLabel.text = self.phoneNumberKit.format(phoneNumber, toType: .international)
+            let phoneNumber = try phoneNumberUtility.parse(number, ignoreType: true)
+            self.parsedNumberLabel.text = phoneNumberUtility.format(phoneNumber, toType: .international)
             self.parsedCountryCodeLabel.text = String(phoneNumber.countryCode)
-            if let regionCode = phoneNumberKit.mainCountry(forCode: phoneNumber.countryCode) {
+            if let regionCode = phoneNumberUtility.mainCountry(forCode: phoneNumber.countryCode) {
                 let country = Locale.current.localizedString(forRegionCode: regionCode)
                 self.parsedCountryLabel.text = country
             }


### PR DESCRIPTION
Fixes #755 .

This renames the class `PhoneNumberKit` to `PhoneNumberUtility` to resolve the issue described in #755 . 

This is a breaking API change, which probably requires a major version bump. See how the sample project needed to be adapted: examples/PhoneBook/Sample/ViewController.swift

## Testing Steps:
* build an artifact (xcframework or .framework) with `BUILD_LIBRARY_FOR_DISTRIBUTION=YES`
* Import the artifact into another project
* make sure Xcode is not reporting errors like this anymore `'PhoneNumber' is not a member type of class 'PhoneNumberKit.PhoneNumberKit'`