### PR TITLE
Bugfix - Data race + Warning

### DIFF
--- a/PhoneNumberKit.xcodeproj/xcshareddata/xcbaselines/3424186D1BB6E5A000EE70E7.xcbaseline/6F93BDF0-844D-4147-9F6C-6BC2FCAF75FB.plist
+++ b/PhoneNumberKit.xcodeproj/xcshareddata/xcbaselines/3424186D1BB6E5A000EE70E7.xcbaseline/6F93BDF0-844D-4147-9F6C-6BC2FCAF75FB.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>PhoneNumberUtilityParsingTests</key>
+		<dict>
+			<key>testParseMultiplePerformance()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.047296</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/PhoneNumberKit.xcodeproj/xcshareddata/xcbaselines/3424186D1BB6E5A000EE70E7.xcbaseline/Info.plist
+++ b/PhoneNumberKit.xcodeproj/xcshareddata/xcbaselines/3424186D1BB6E5A000EE70E7.xcbaseline/Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>runDestinationsByUUID</key>
+	<dict>
+		<key>6F93BDF0-844D-4147-9F6C-6BC2FCAF75FB</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>0</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>Apple M3 Pro</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>0</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>12</integer>
+				<key>modelCode</key>
+				<string>Mac15,7</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>12</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>arm64</string>
+			<key>targetDevice</key>
+			<dict>
+				<key>modelCode</key>
+				<string>iPhone17,4</string>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.iphonesimulator</string>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/PhoneNumberKitTests/PhoneNumberUtilityParsingTests.swift
+++ b/PhoneNumberKitTests/PhoneNumberUtilityParsingTests.swift
@@ -352,6 +352,50 @@ final class PhoneNumberUtilityParsingTests: XCTestCase {
         XCTAssertLessThan(timeInterval, 1)
     }
 
+    func testParseMultipleWithValidNumbers() {
+        let numbers = ["+5491187654321", "+5491187654322", "+5491187654323"]
+        let result = sut.parseManager.parseMultiple(numbers, withRegion: "AR", ignoreType: true)
+        XCTAssertEqual(result.count, 3)
+        XCTAssertTrue(result.allSatisfy { $0.type != .notParsed })
+    }
+
+    func testParseMultipleWithInvalidNumbers() {
+        let numbers = ["invalid", "12345", "abc"]
+        let result = sut.parseManager.parseMultiple(numbers, withRegion: "AR", ignoreType: true)
+        XCTAssertEqual(result.count, 0)
+    }
+
+    func testParseMultipleWithMixedNumbers() {
+        let numbers = ["+5491187654321", "invalid", "+5491187654322"]
+        let result = sut.parseManager.parseMultiple(numbers, withRegion: "AR", ignoreType: true)
+        XCTAssertEqual(result.count, 2)
+    }
+
+    func testParseMultipleWithEmptyArray() {
+        let result = sut.parseManager.parseMultiple([], withRegion: "AR", ignoreType: true)
+        XCTAssertEqual(result.count, 0)
+    }
+
+    func testParseMultipleWithReturnFailedNumbers() {
+        let numbers = ["+5491187654321", "invalid", "+5491187654322"]
+        let result = sut.parseManager.parseMultiple(numbers, withRegion: "AR", ignoreType: true, shouldReturnFailedEmptyNumbers: true)
+        XCTAssertEqual(result.count, 3)
+        XCTAssertEqual(result[1].type, .notParsed)
+    }
+
+    func testParseMultipleWithDifferentRegions() {
+        let numbers = ["+5491187654321", "+14155552671"]
+        let result = sut.parseManager.parseMultiple(numbers, withRegion: "US", ignoreType: true)
+        XCTAssertEqual(result.count, 2)
+    }
+
+    func testParseMultiplePerformance() {
+        measure {
+            let numbers = Array(repeating: "+5491187654321", count: 1000)
+            _ = sut.parseManager.parseMultiple(numbers, withRegion: "AR", ignoreType: true)
+        }
+    }
+
     func testUANumber() throws {
         let phoneNumber1 = try sut.parse("501887766", withRegion: "UA")
         XCTAssertNotNil(phoneNumber1)


### PR DESCRIPTION
This PR aims to address #825

### What was done:
1. Added unit tests while on `master` to cover any possible outcomes of `ParseManager.parseMultiple` including a measure test.
2. Addressed the warning by removing `DispatchQueue.concurrentPerform`
3. Committed the baseline plists (set while on `master` writing the tests

### Notes:
1. Checked test run times and it seems this approach takes less time to complete:

![Screenshot 2024-12-19 at 19 23 23](https://github.com/user-attachments/assets/357a6cea-497e-4fed-a538-140dc314bbfa)
![Screenshot 2024-12-19 at 19 23 34](https://github.com/user-attachments/assets/9cde4536-ce09-4ffa-ad0e-12b9f9d53b9e)
(used the existing test as a baseline)

2. This approach drops `DispatchQueue.concurrentPerform` but maybe that is not something that should be done?
3. An alternate approach to fixing the data race could be a lock. Let me know if that is preferred.