### PR TITLE
Use version 4 in setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ The [Swift Package Manager](https://swift.org/package-manager/) is now the prefe
 From Xcode 11+ :
 
 1. Select File > Swift Packages > Add Package Dependency. Enter `https://github.com/marmelroy/PhoneNumberKit.git` in the "Choose Package Repository" dialog.
-2. In the next page, specify the version resolving rule as "Up to Next Major" from "3.7.0".
+2. In the next page, specify the version resolving rule as "Up to Next Major" from "4.0.0".
 3. After Xcode checked out the source and resolving the version, you can choose the "PhoneNumberKit" library and add it to your app target.
 
 For more info, read [Adding Package Dependencies to Your App](https://developer.apple.com/documentation/xcode/adding_package_dependencies_to_your_app) from Apple.
@@ -164,7 +164,7 @@ Alternatively, you can also add PhoneNumberKit to your `Package.swift` file:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/marmelroy/PhoneNumberKit", from: "3.7.0")
+    .package(url: "https://github.com/marmelroy/PhoneNumberKit", from: "4.0.0")
 ]
 ```
 
@@ -188,5 +188,5 @@ github "marmelroy/PhoneNumberKit"
 ### Setting up with [CocoaPods](http://cocoapods.org/?q=PhoneNumberKit)
 
 ```ruby
-pod 'PhoneNumberKit', '~> 3.7'
+pod 'PhoneNumberKit', '~> 4.0'
 ```


### PR DESCRIPTION
Use version 4 in setup instructions, as version 4 has been out for quite some time - https://github.com/marmelroy/PhoneNumberKit/releases/tag/4.0.0