### PR TITLE
Make `CodingUserInfoKey`s Public and Improve Documentation

### DIFF
--- a/PhoneNumberKit/Constants.swift
+++ b/PhoneNumberKit/Constants.swift
@@ -19,31 +19,30 @@ enum PhoneNumberCountryCodeSource {
 
 // MARK: Public Enums
 
-/// Enumeration for parsing error types
-///
-/// - GeneralError: A general error occured.
-/// - InvalidCountryCode: A country code could not be found or the one found was invalid
-/// - InvalidNumber: The string provided is not a number
-/// - TooLong: The string provided is too long to be a valid number
-/// - TooShort: The string provided is too short to be a valid number
-/// - Deprecated: The method used was deprecated
-/// - metadataNotFound: PhoneNumberKit was unable to read the included metadata
-/// - ambiguousNumber: The string could not be resolved to a single valid number
-public enum PhoneNumberError: Error, Equatable {
+/// An error type representing failures that may occur during phone number parsing or validation.
+public enum PhoneNumberError: Error, Equatable, Sendable {
+    /// A general or unknown error occurred.
     case generalError
+    /// The provided country code is missing or invalid.
     case invalidCountryCode
+    /// The provided input is not a valid number.
     case invalidNumber
+    /// The input number is too long to be considered valid.
     case tooLong
+    /// The input number is too short to be considered valid.
     case tooShort
+    /// A deprecated method was used and is no longer supported.
     case deprecated
+    /// Required metadata could not be found during parsing.
     case metadataNotFound
+    /// The input could be interpreted as more than one valid phone number.
     case ambiguousNumber(phoneNumbers: Set<PhoneNumber>)
 }
 
 extension PhoneNumberError: LocalizedError {
     public var errorDescription: String? {
         switch self {
-        case .generalError: return NSLocalizedString("An error occured while validating the phone number.", comment: "")
+        case .generalError: return NSLocalizedString("An error occurred while validating the phone number.", comment: "")
         case .invalidCountryCode: return NSLocalizedString("The country code is invalid.", comment: "")
         case .invalidNumber: return NSLocalizedString("The number provided is invalid.", comment: "")
         case .tooLong: return NSLocalizedString("The number provided is too long.", comment: "")
@@ -55,43 +54,51 @@ extension PhoneNumberError: LocalizedError {
     }
 }
 
-public enum PhoneNumberFormat {
-    case e164 // +33689123456
-    case international // +33 6 89 12 34 56
-    case national // 06 89 12 34 56
+/// Formatting options for displaying a phone number.
+public enum PhoneNumberFormat: String, Codable, Sendable {
+    /// Format: +33689123456
+    case e164
+    /// Format: +33 6 89 12 34 56
+    case international
+    /// Format: 06 89 12 34 56
+    case national
 }
 
-/// Phone number type enumeration
-/// - fixedLine: Fixed line numbers
-/// - mobile: Mobile numbers
-/// - fixedOrMobile: Either fixed or mobile numbers if we can't tell conclusively.
-/// - pager: Pager numbers
-/// - personalNumber: Personal number numbers
-/// - premiumRate: Premium rate numbers
-/// - sharedCost: Shared cost numbers
-/// - tollFree: Toll free numbers
-/// - voicemail: Voice mail numbers
-/// - vOIP: Voip numbers
-/// - uan: UAN numbers
-/// - unknown: Unknown number type
+/// The type of a phone number, determined after parsing.
 public enum PhoneNumberType: String, Codable, Sendable {
+    /// A fixed line (landline) number.
     case fixedLine
+    /// A mobile number.
     case mobile
+    /// A number that could be either fixed line or mobile.
     case fixedOrMobile
+    /// A pager number.
     case pager
+    /// A personal number assigned to a person (not a device).
     case personalNumber
+    /// A premium-rate number.
     case premiumRate
+    /// A shared-cost number.
     case sharedCost
+    /// A toll-free number.
     case tollFree
+    /// A voicemail number.
     case voicemail
+    /// A voice-over-IP (VoIP) number.
     case voip
+    /// A UAN (Universal Access Number).
     case uan
+    /// A number that could not be classified.
     case unknown
+    /// The number has not been parsed and its type is unknown.
     case notParsed
 }
 
-public enum PossibleLengthType: String, Codable {
+/// Indicates the scope or context in which a number length is valid.
+public enum PossibleLengthType: String, Codable, Sendable {
+    /// The number length is valid for national dialing.
     case national
+    /// The number length is valid only for local dialing.
     case localOnly
 }
 

--- a/PhoneNumberKit/MetadataTypes.swift
+++ b/PhoneNumberKit/MetadataTypes.swift
@@ -8,91 +8,95 @@
 
 import Foundation
 
-/// MetadataTerritory object
-/// - Parameter codeID: ISO 3166 compliant region code
-/// - Parameter countryCode: International country code
-/// - Parameter internationalPrefix: International prefix. Optional.
-/// - Parameter mainCountryForCode: Whether the current metadata is the main country for its country code.
-/// - Parameter nationalPrefix: National prefix
-/// - Parameter nationalPrefixFormattingRule: National prefix formatting rule
-/// - Parameter nationalPrefixForParsing: National prefix for parsing
-/// - Parameter nationalPrefixTransformRule: National prefix transform rule
-/// - Parameter emergency: MetadataPhoneNumberDesc for emergency numbers
-/// - Parameter fixedLine: MetadataPhoneNumberDesc for fixed line numbers
-/// - Parameter generalDesc: MetadataPhoneNumberDesc for general numbers
-/// - Parameter mobile: MetadataPhoneNumberDesc for mobile numbers
-/// - Parameter pager: MetadataPhoneNumberDesc for pager numbers
-/// - Parameter personalNumber: MetadataPhoneNumberDesc for personal number numbers
-/// - Parameter premiumRate: MetadataPhoneNumberDesc for premium rate numbers
-/// - Parameter sharedCost: MetadataPhoneNumberDesc for shared cost numbers
-/// - Parameter tollFree: MetadataPhoneNumberDesc for toll free numbers
-/// - Parameter voicemail: MetadataPhoneNumberDesc for voice mail numbers
-/// - Parameter voip: MetadataPhoneNumberDesc for voip numbers
-/// - Parameter uan: MetadataPhoneNumberDesc for uan numbers
-/// - Parameter leadingDigits: Optional leading digits for the territory
+/// Represents metadata for a specific geographical territory used in phone number parsing.
 public struct MetadataTerritory: Decodable {
+    /// ISO 3166-compliant region code.
     public let codeID: String
+    /// International dialing country code.
     public let countryCode: UInt64
+    /// International dialing prefix (e.g., "011").
     public let internationalPrefix: String?
+    /// Indicates whether this is the primary country for the associated country code.
     public let mainCountryForCode: Bool
+    /// National dialing prefix (e.g., "0").
     public let nationalPrefix: String?
+    /// Rule for formatting the national prefix in numbers.
     public let nationalPrefixFormattingRule: String?
+    /// Alternate national prefix used for parsing.
     public let nationalPrefixForParsing: String?
+    /// Rule to transform the national prefix before parsing.
     public let nationalPrefixTransformRule: String?
+    /// Preferred extension prefix (e.g., " ext. ").
     public let preferredExtnPrefix: String?
+    /// Metadata description for emergency numbers.
     public let emergency: MetadataPhoneNumberDesc?
+    /// Metadata description for fixed-line numbers.
     public let fixedLine: MetadataPhoneNumberDesc?
+    /// Metadata description for general numbers.
     public let generalDesc: MetadataPhoneNumberDesc?
+    /// Metadata description for mobile numbers.
     public let mobile: MetadataPhoneNumberDesc?
+    /// Metadata description for pager numbers.
     public let pager: MetadataPhoneNumberDesc?
+    /// Metadata description for personal numbers.
     public let personalNumber: MetadataPhoneNumberDesc?
+    /// Metadata description for premium-rate numbers.
     public let premiumRate: MetadataPhoneNumberDesc?
+    /// Metadata description for shared-cost numbers.
     public let sharedCost: MetadataPhoneNumberDesc?
+    /// Metadata description for toll-free numbers.
     public let tollFree: MetadataPhoneNumberDesc?
+    /// Metadata description for voicemail numbers.
     public let voicemail: MetadataPhoneNumberDesc?
+    /// Metadata description for VoIP numbers.
     public let voip: MetadataPhoneNumberDesc?
+    /// Metadata description for UAN numbers.
     public let uan: MetadataPhoneNumberDesc?
+    /// List of formatting patterns used within this territory.
     public let numberFormats: [MetadataPhoneNumberFormat]
+    /// Optional leading digits used to narrow down matching within the territory.
     public let leadingDigits: String?
 }
 
-/// MetadataPhoneNumberDesc object
-/// - Parameter exampleNumber: An example phone number for the given type. Optional.
-/// - Parameter nationalNumberPattern:  National number regex pattern. Optional.
-/// - Parameter possibleNumberPattern:  Possible number regex pattern. Optional.
-/// - Parameter possibleLengths: Possible phone number lengths. Optional.
+/// Describes a specific type of phone number (e.g., mobile, fixed-line) using metadata.
 public struct MetadataPhoneNumberDesc: Decodable {
+    /// Example number demonstrating a valid format for this type.
     public let exampleNumber: String?
+    /// Regular expression pattern for national numbers of this type.
     public let nationalNumberPattern: String?
+    /// Regular expression pattern for possible numbers of this type.
     public let possibleNumberPattern: String?
+    /// Valid number lengths for this type.
     public let possibleLengths: MetadataPossibleLengths?
 }
 
+/// Describes valid lengths for a phone number, either nationally or locally.
 public struct MetadataPossibleLengths: Decodable {
+    /// Valid national number lengths (as a comma-separated string).
     let national: String?
+    /// Valid local-only number lengths (as a comma-separated string).
     let localOnly: String?
 }
 
-/// MetadataPhoneNumberFormat object
-/// - Parameter pattern: Regex pattern. Optional.
-/// - Parameter format: Formatting template. Optional.
-/// - Parameter intlFormat: International formatting template. Optional.
-///
-/// - Parameter leadingDigitsPatterns: Leading digits regex pattern. Optional.
-/// - Parameter nationalPrefixFormattingRule: National prefix formatting rule. Optional.
-/// - Parameter nationalPrefixOptionalWhenFormatting: National prefix optional bool. Optional.
-/// - Parameter domesticCarrierCodeFormattingRule: Domestic carrier code formatting rule. Optional.
+/// Describes how a phone number should be formatted within a specific context.
 public struct MetadataPhoneNumberFormat: Decodable {
+    /// Regular expression pattern that matches numbers this format applies to.
     public let pattern: String?
+    /// Format string used to output the number.
     public let format: String?
+    /// International version of the format string.
     public let intlFormat: String?
+    /// List of regular expressions for leading digits to match before applying the format.
     public let leadingDigitsPatterns: [String]?
+    /// Rule for inserting the national prefix when formatting.
     public var nationalPrefixFormattingRule: String?
+    /// Indicates whether the national prefix is optional during formatting.
     public let nationalPrefixOptionalWhenFormatting: Bool?
+    /// Rule for formatting the domestic carrier code.
     public let domesticCarrierCodeFormattingRule: String?
 }
 
-/// Internal object for metadata parsing
+/// Internal structure used for decoding metadata from bundled resources.
 struct PhoneNumberMetadata: Decodable {
     var territories: [MetadataTerritory]
 }

--- a/PhoneNumberKit/PhoneNumber.swift
+++ b/PhoneNumberKit/PhoneNumber.swift
@@ -8,21 +8,21 @@
 
 import Foundation
 
-/// Parsed phone number object
-///
-/// - numberString: String used to generate phone number struct
-/// - countryCode: Country dialing code as an unsigned. Int.
-/// - leadingZero: Some countries (e.g. Italy) require leading zeros. Bool.
-/// - nationalNumber: National number as an unsigned. Int.
-/// - numberExtension: Extension if available. String. Optional
-/// - type: Computed phone number type on access. Returns from an enumeration - PNPhoneNumberType.
+/// A parsed phone number representation.
 public struct PhoneNumber: Sendable {
+    /// The original string used to generate this phone number.
     public let numberString: String
+    /// The international dialing code (e.g., 1 for US/Canada, 44 for UK).
     public let countryCode: UInt64
+    /// Indicates whether the phone number includes a leading zero, as required by some countries (e.g., Italy).
     public let leadingZero: Bool
+    /// The national portion of the phone number, excluding the country code.
     public let nationalNumber: UInt64
+    /// An optional phone number extension, if available.
     public let numberExtension: String?
+    /// The type of phone number (e.g., mobile, fixed line), as determined during parsing.
     public let type: PhoneNumberType
+    /// The region identifier associated with the phone number (e.g., "US", "GB").
     public let regionID: String?
 }
 

--- a/PhoneNumberKit/UI/CountryCodePickerOptions.swift
+++ b/PhoneNumberKit/UI/CountryCodePickerOptions.swift
@@ -9,19 +9,24 @@
 #if os(iOS)
 import UIKit
 
-/// CountryCodePickerOptions object
-/// - Parameter backgroundColor: UIColor used for background
-/// - Parameter separatorColor: UIColor used for the separator line between cells
-/// - Parameter textLabelColor: UIColor for the TextLabel (Country code)
-/// - Parameter textLabelFont: UIFont for the TextLabel (Country code)
-/// - Parameter detailTextLabelColor: UIColor for the DetailTextLabel (Country name)
-/// - Parameter detailTextLabelFont: UIFont for the DetailTextLabel (Country name)
-/// - Parameter tintColor: Default TintColor used on the view
-/// - Parameter cellBackgroundColor: UIColor for the cell background
-/// - Parameter cellBackgroundColorSelection: UIColor for the cell selectedBackgroundView
-public struct CountryCodePickerOptions {
+/// Configuration options for customizing the appearance of the country code picker.
+public struct CountryCodePickerOptions: Sendable {
+    
+    /// Creates a new `CountryCodePickerOptions` instance with all properties set to `nil`.
     public init() { }
 
+    /// Creates a new `CountryCodePickerOptions` instance with the specified appearance options.
+    ///
+    /// - Parameters:
+    ///   - backgroundColor: The background color of the view.
+    ///   - separatorColor: The color of the separator line between cells.
+    ///   - textLabelColor: The color of the main text label (country code).
+    ///   - textLabelFont: The font of the main text label (country code).
+    ///   - detailTextLabelColor: The color of the detail text label (country name).
+    ///   - detailTextLabelFont: The font of the detail text label (country name).
+    ///   - tintColor: The tint color applied to interactive elements in the view.
+    ///   - cellBackgroundColor: The background color of each table cell.
+    ///   - cellBackgroundColorSelection: The background color of a selected table cell.
     public init(backgroundColor: UIColor? = nil,
                 separatorColor: UIColor? = nil,
                 textLabelColor: UIColor? = nil,
@@ -41,15 +46,25 @@ public struct CountryCodePickerOptions {
         self.cellBackgroundColor = cellBackgroundColor
         self.cellBackgroundColorSelection = cellBackgroundColorSelection
     }
+    
 
+    /// The background color of the entire picker view.
     public var backgroundColor: UIColor?
+    /// The color of the separator lines between cells.
     public var separatorColor: UIColor?
+    /// The color of the main text label showing the country code.
     public var textLabelColor: UIColor?
+    /// The font used for the main text label (country code).
     public var textLabelFont: UIFont?
+    /// The color of the detail text label showing the country name.
     public var detailTextLabelColor: UIColor?
+    /// The font used for the detail text label (country name).
     public var detailTextLabelFont: UIFont?
+    /// The tint color used throughout the view (e.g., for selection indicators).
     public var tintColor: UIColor?
+    /// The background color of individual table cells.
     public var cellBackgroundColor: UIColor?
+    /// The background color of a selected table cell.
     public var cellBackgroundColorSelection: UIColor?
 }
 #endif


### PR DESCRIPTION
- Added public access to previously internal types and strategies for encoding and decoding `PhoneNumber`.
- Introduced a `PhoneNumberUtilityProvider` typealias to clarify utility injection via userInfo.
- Updated documentation across public types, properties, and initializers to follow the DocC format for better Xcode integration and DocC compatibility.