### PR TITLE
fix: add `@MainActor` to `CountryCodePickerDelegate`

### DIFF
--- a/PhoneNumberKit/UI/CountryCodePickerViewController.swift
+++ b/PhoneNumberKit/UI/CountryCodePickerViewController.swift
@@ -2,6 +2,7 @@
 
 import UIKit
 
+@MainActor
 public protocol CountryCodePickerDelegate: AnyObject {
     func countryCodePickerViewControllerDidPickCountry(_ country: CountryCodePickerViewController.Country)
 }


### PR DESCRIPTION
 ## Summary
  - Add `@MainActor` annotation to
  `CountryCodePickerDelegate` protocol for Swift 6
  strict concurrency compliance
