### PR TITLE
Ensures PhoneNumberTextField always uses telephoneNumber content type

### DIFF
--- a/PhoneNumberKit/UI/PhoneNumberTextField.swift
+++ b/PhoneNumberKit/UI/PhoneNumberTextField.swift
@@ -33,6 +33,11 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
             return super.text
         }
     }
+    /// Forces textContentType to .telephoneNumber for autofill support.
+    override open var textContentType: UITextContentType! {
+        get { .telephoneNumber }
+        set {}
+    }
 
     /// allows text to be set without formatting
     open func setTextUnformatted(newValue: String?) {


### PR DESCRIPTION
## Summary

Adds `textContentType` override to `PhoneNumberTextField` to ensure it always uses `.telephoneNumber` content type. This change is required for accessibility review compliance.

## Changes

- Override `textContentType` to always return `.telephoneNumber`

## Benefits

- **Accessibility Compliance**: Required for accessibility review
- Enables iOS autofill suggestions for phone numbers
- Ensures consistent behavior regardless of external configuration