### PR TITLE
Refactor parsePrefixAsIdd to fix String/NSString length mismatch (fixes #889)

### DIFF
--- a/PhoneNumberKit/PhoneNumberParser.swift
+++ b/PhoneNumberKit/PhoneNumberParser.swift
@@ -169,24 +169,25 @@ final class PhoneNumberParser {
     func parsePrefixAsIdd(_ number: inout String, iddPattern: String) -> Bool {
         if self.regex.stringPositionByRegex(iddPattern, string: number) == 0 {
             do {
-                guard let matched = try regex.regexMatches(iddPattern as String, string: number as String).first else {
+                guard let matched = try regex.regexMatches(iddPattern as String, string: number).first,
+                      let matchRange = Range(matched.range, in: number) else {
                     return false
                 }
-                let matchedString = number.substring(with: matched.range)
-                let matchEnd = matchedString.count
-                let remainString = (number as NSString).substring(from: matchEnd)
+                let remainString = String(number[matchRange.upperBound...])
                 let capturingDigitPatterns = try NSRegularExpression(pattern: PhoneNumberPatterns.capturingDigitPattern, options: NSRegularExpression.Options.caseInsensitive)
-                let matchedGroups = capturingDigitPatterns.matches(in: remainString as String)
-                if let firstMatch = matchedGroups.first {
-                    let digitMatched = remainString.substring(with: firstMatch.range) as NSString
-                    if digitMatched.length > 0 {
-                        let normalizedGroup = self.regex.stringByReplacingOccurrences(digitMatched as String, map: PhoneNumberPatterns.allNormalizationMappings)
+                let range = NSRange(location: 0, length: remainString.utf16.count)
+                let matchedGroups = capturingDigitPatterns.matches(in: remainString, range: range)
+                if let firstMatch = matchedGroups.first,
+                   let range = Range(firstMatch.range, in: remainString) {
+                    let digitMatched = String(remainString[range])
+                    if !digitMatched.isEmpty {
+                        let normalizedGroup = self.regex.stringByReplacingOccurrences(digitMatched, map: PhoneNumberPatterns.allNormalizationMappings)
                         if normalizedGroup == "0" {
                             return false
                         }
                     }
                 }
-                number = remainString as String
+                number = remainString
                 return true
             } catch {
                 return false


### PR DESCRIPTION
fixes #889 

## Summary  
This PR addresses a potential \_String length conflation\_ issue when bridging Swift \`String\` to Foundation APIs that operate on UTF\-\`16\` (\`NSString\`/\`NSRegularExpression\`). The code now uses \`utf16.count\` when creating an \`NSRange\`, ensuring the range length matches what \`NSRegularExpression\` expects and preventing incorrect matches or out\-of\-bounds behavior for non\-ASCII input.

## Problem  
Swift \`String.count\` returns the number of extended grapheme clusters (user\-perceived characters), not the UTF\-\`16\` code unit length used by \`NSString\` and \`NSRegularExpression\`. Using \`String.count\` to build an \`NSRange\` can cause mismatched ranges for characters represented by surrogate pairs or combining sequences, leading to incorrect regex results.

## Fix  
When building the \`NSRange\` used for regex matching, the implementation uses:

- \`NSRange(location: 0, length: remainString.utf16.count)\`

This aligns the range length with Foundation’s UTF\-\`16\` indexing model.

## Impact / Risk  
Low risk. The change only affects the range length passed to regex evaluation and improves correctness on Unicode input. Behavior for ASCII\-only input is unchanged.

## Testing  
- Verified behavior with existing unit tests.

## Notes  
This change prevents a class of issues typically flagged by static analyzers as \_String length conflation\_ when mixing Swift \`String\` indexing semantics with \`NSString\`/\`NSRegularExpression\` APIs.